### PR TITLE
fix: use valid Vercel path patterns instead of regex

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -52,7 +52,7 @@
       ]
     },
     {
-      "source": "/assets/(.*\\.(mp3|wav|ogg))",
+      "source": "/assets/:path*.mp3",
       "headers": [
         {
           "key": "Cache-Control",
@@ -61,7 +61,79 @@
       ]
     },
     {
-      "source": "/(.*\\.(webp|avif|jpg|jpeg|png|svg|gif))",
+      "source": "/assets/:path*.wav",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=604800, stale-while-revalidate=86400"
+        }
+      ]
+    },
+    {
+      "source": "/assets/:path*.ogg",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=604800, stale-while-revalidate=86400"
+        }
+      ]
+    },
+    {
+      "source": "/:path*.webp",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/:path*.avif",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/:path*.jpg",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/:path*.jpeg",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/:path*.png",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/:path*.svg",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/:path*.gif",
       "headers": [
         {
           "key": "Cache-Control",
@@ -107,7 +179,16 @@
       ]
     },
     {
-      "source": "/(.*\\.html?)",
+      "source": "/:path*.html",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/:path*.htm",
       "headers": [
         {
           "key": "Cache-Control",


### PR DESCRIPTION
Replace unsupported regex patterns in vercel.json headers with
valid path-to-regexp syntax using :path* parameter matching.