### PR TITLE
fix: correct domain URL from stillouder.space to stilllouder.space

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,7 +1,7 @@
-Contact: mailto:security@stillouder.space
+Contact: mailto:security@stilllouder.space
 Expires: 2026-01-11T00:00:00.000Z
 Preferred-Languages: es, en
-Canonical: https://stillouder.space/.well-known/security.txt
+Canonical: https://stilllouder.space/.well-known/security.txt
 
 # Security Policy
 # If you discover a security vulnerability, please report it responsibly

--- a/public/al-vacio-pre-release.html
+++ b/public/al-vacio-pre-release.html
@@ -35,7 +35,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="manifest" href="/assets/site.webmanifest" />
-    <link rel="canonical" href="https://stillouder.space/al-vacio-pre-release" />
+    <link rel="canonical" href="https://stilllouder.space/al-vacio-pre-release" />
 
     <!-- Social Media Verification -->
     <link rel="me" href="https://www.instagram.com/stilllouder/" />
@@ -59,7 +59,7 @@
       property="og:description"
       content="Escucha el pre-lanzamiento de 'Al Vacío' de Still Louder. Disfruta la música, comparte tu opinión y síguenos en redes sociales."
     />
-    <meta property="og:url" content="https://stillouder.space/al-vacio-pre-release" />
+    <meta property="og:url" content="https://stilllouder.space/al-vacio-pre-release" />
     <meta property="og:site_name" content="Still Louder" />
     <meta property="og:image" content="https://i.imgur.com/CoA13WN.jpg" />
     <meta property="og:image:secure_url" content="https://i.imgur.com/CoA13WN.jpg" />
@@ -69,9 +69,9 @@
     <meta property="og:image:height" content="1200" />
 
     <!-- Music-specific Open Graph -->
-    <meta property="music:musician" content="https://stillouder.space/" />
+    <meta property="music:musician" content="https://stilllouder.space/" />
     <meta property="music:release_date" content="2025-07-28" />
-    <meta property="music:song" content="https://stillouder.space/al-vacio-pre-release" />
+    <meta property="music:song" content="https://stilllouder.space/al-vacio-pre-release" />
     <meta property="music:duration" content="240" />
 
     <!-- Twitter Card -->
@@ -92,7 +92,7 @@
         "@context": "https://schema.org",
         "@type": "MusicRecording",
         "name": "Al Vacío",
-        "url": "https://stillouder.space/al-vacio-pre-release",
+        "url": "https://stilllouder.space/al-vacio-pre-release",
         "image": "https://i.imgur.com/CoA13WN.jpg",
         "datePublished": "2025-07-28",
         "genre": ["Rock", "Alternative Rock"],
@@ -100,7 +100,7 @@
         "duration": "PT4M",
         "byArtist": {
           "@type": "MusicGroup",
-          "@id": "https://stillouder.space/#band",
+          "@id": "https://stilllouder.space/#band",
           "name": "Still Louder",
           "genre": ["Rock", "Alternative Rock"],
           "foundingLocation": {
@@ -124,7 +124,7 @@
           "name": "Al Vacío",
           "composer": {
             "@type": "MusicGroup",
-            "@id": "https://stillouder.space/#band"
+            "@id": "https://stilllouder.space/#band"
           },
           "inLanguage": "es"
         },
@@ -134,7 +134,7 @@
           "albumReleaseType": "Single",
           "datePublished": "2025-07-28",
           "byArtist": {
-            "@id": "https://stillouder.space/#band"
+            "@id": "https://stilllouder.space/#band"
           }
         }
       }
@@ -145,9 +145,9 @@
       {
         "@context": "https://schema.org",
         "@type": "MusicGroup",
-        "@id": "https://stillouder.space/#band",
+        "@id": "https://stilllouder.space/#band",
         "name": "Still Louder",
-        "url": "https://stillouder.space/",
+        "url": "https://stilllouder.space/",
         "logo": "https://i.imgur.com/CoA13WN.jpg",
         "image": "https://i.imgur.com/CoA13WN.jpg",
         "genre": ["Rock", "Alternative Rock"],
@@ -176,13 +176,13 @@
       {
         "@context": "https://schema.org",
         "@type": "WebPage",
-        "url": "https://stillouder.space/al-vacio-pre-release",
+        "url": "https://stilllouder.space/al-vacio-pre-release",
         "name": "Still Louder - Al Vacío | Pre-lanzamiento",
         "description": "Escucha el pre-lanzamiento de 'Al Vacío' de Still Louder",
         "inLanguage": "es",
         "isPartOf": {
           "@type": "WebSite",
-          "url": "https://stillouder.space/",
+          "url": "https://stilllouder.space/",
           "name": "Still Louder"
         },
         "breadcrumb": {
@@ -192,13 +192,13 @@
               "@type": "ListItem",
               "position": 1,
               "name": "Inicio",
-              "item": "https://stillouder.space/"
+              "item": "https://stilllouder.space/"
             },
             {
               "@type": "ListItem",
               "position": 2,
               "name": "Al Vacío - Pre-lanzamiento",
-              "item": "https://stillouder.space/al-vacio-pre-release"
+              "item": "https://stilllouder.space/al-vacio-pre-release"
             }
           ]
         }

--- a/public/assets/js/config.js
+++ b/public/assets/js/config.js
@@ -83,7 +83,7 @@ export const CONFIG = {
   // Site Information
   site: {
     name: 'Still Louder',
-    url: 'https://stillouder.space/',
+    url: 'https://stilllouder.space/',
     description:
       '¡Ya disponible! Escucha "Al Vacío", el nuevo sencillo de Still Louder, en todas las plataformas digitales.',
     locale: 'es_PA',

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -15,7 +15,7 @@ const CONFIG = {
   share: {
     title: 'Still Louder - Al Vacío',
     text: 'Escucha "Al Vacío" de Still Louder - Rock panameño disponible ahora en todas las plataformas.',
-    url: 'https://stillouder.space/'
+    url: 'https://stilllouder.space/'
   },
   analytics: {
     enabled: typeof gtag !== 'undefined'

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
     />
     <meta
       name="keywords"
-      content="Still Louder, Al Vacío, música, sencillo, rock, Panamá, lanzamiento, banda, streaming, Spotify, Apple Music, Deezer, YouTube, Google Play, Amazon Music, 2025, nueva música, rock panameño, escuchar, plataformas digitales"
+      content="Still Louder, Al Vacío, música, sencillo, rock, heavy metal, Panamá, Chiriquí, banda, streaming, Spotify, Apple Music, Deezer, YouTube, Amazon Music, 2025, rock panameño, Hard Rock Rising, In Hostilia, Bomba de Tiempo, Litio+"
     />
     <meta name="author" content="Still Louder" />
     <meta
@@ -655,23 +655,27 @@
               </header>
               <div class="about-text">
                 <p class="reveal-up">
-                  <strong>Still Louder</strong> es una banda de heavy metal originaria de
-                  <strong>Chiriquí, Panamá</strong>, formada en 2009. Su primer toque oficial fue el
-                  31 de octubre de ese año.
+                  <strong>Still Louder</strong> es una banda de rock originaria de
+                  <strong>Chiriquí, Panamá</strong>, formada en 2009. Su sonido potente y enérgico
+                  evoca la esencia del heavy metal, con guitarras pesadas, bajo profundo y una
+                  batería arrolladora.
                 </p>
                 <p class="reveal-up">
-                  Con un sonido que fusiona heavy metal clásico con elementos modernos, la banda ha
-                  sido influenciada por Metallica, Megadeth, Ángeles del Infierno y Rata Blanca.
+                  Ganadores del <strong>Hard Rock Rising Panamá 2013</strong> y ubicados entre los
+                  <strong>35 grupos más votados a nivel mundial</strong> en dicha competencia. En
+                  2015, su álbum <em>In Hostilia</em> apareció en el
+                  <strong>Top 250 de Headbangers Latino América</strong>.
                 </p>
                 <p class="reveal-up">
-                  Ganadores del <strong>Hard Rock Rising Panamá 2013</strong>, han compartido
-                  escenario con bandas internacionales como 2 Minutos (Argentina) y Mantra (Costa
-                  Rica).
+                  Han compartido escenario con bandas internacionales como 2 Minutos (Argentina) y
+                  Mantra (Costa Rica), además de destacadas agrupaciones panameñas como Cabeza de
+                  Martillo, Llevarte a Marte y MD.
                 </p>
                 <p class="reveal-up">
                   <em
-                    >"Al Vacío" marca una nueva etapa en su trayectoria, explorando temas de
-                    introspección y la búsqueda de significado.</em
+                    >"Al Vacío" (2025) es su más reciente sencillo, siguiendo a "Bomba de Tiempo"
+                    (2023) y "Litio+" (2024), marcando una nueva etapa de introspección y búsqueda
+                    de significado.</em
                   >
                 </p>
               </div>

--- a/public/index.html
+++ b/public/index.html
@@ -35,7 +35,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="manifest" href="/assets/site.webmanifest" />
-    <link rel="canonical" href="https://stillouder.space/" />
+    <link rel="canonical" href="https://stilllouder.space/" />
 
     <!-- Social Media Verification -->
     <link rel="me" href="https://www.instagram.com/stilllouder/" />
@@ -70,7 +70,7 @@
       property="og:description"
       content="Escucha 'Al Vacío' de Still Louder en Spotify, Apple Music, YouTube, Deezer y Amazon Music. Rock panameño disponible ahora."
     />
-    <meta property="og:url" content="https://stillouder.space/" />
+    <meta property="og:url" content="https://stilllouder.space/" />
     <meta property="og:site_name" content="Still Louder" />
     <meta property="og:image" content="https://i.imgur.com/CoA13WN.jpg" />
     <meta property="og:image:secure_url" content="https://i.imgur.com/CoA13WN.jpg" />
@@ -80,9 +80,9 @@
     <meta property="og:image:height" content="1200" />
 
     <!-- Music-specific Open Graph -->
-    <meta property="music:musician" content="https://stillouder.space/" />
+    <meta property="music:musician" content="https://stilllouder.space/" />
     <meta property="music:release_date" content="2025-07-28" />
-    <meta property="music:song" content="https://stillouder.space/" />
+    <meta property="music:song" content="https://stilllouder.space/" />
     <meta property="music:duration" content="240" />
 
     <!-- Platform Links for Discovery -->
@@ -118,7 +118,7 @@
         "@context": "https://schema.org",
         "@type": "MusicRecording",
         "name": "Al Vacío",
-        "url": "https://stillouder.space/",
+        "url": "https://stilllouder.space/",
         "image": "https://i.imgur.com/CoA13WN.jpg",
         "datePublished": "2025-07-28",
         "genre": ["Heavy Metal", "Rock"],
@@ -127,7 +127,7 @@
         "isrcCode": "",
         "byArtist": {
           "@type": "MusicGroup",
-          "@id": "https://stillouder.space/#band",
+          "@id": "https://stilllouder.space/#band",
           "name": "Still Louder",
           "genre": ["Heavy Metal", "Rock"],
           "foundingLocation": {
@@ -151,7 +151,7 @@
           "name": "Al Vacío",
           "composer": {
             "@type": "MusicGroup",
-            "@id": "https://stillouder.space/#band"
+            "@id": "https://stilllouder.space/#band"
           },
           "inLanguage": "es",
           "iswcCode": ""
@@ -162,7 +162,7 @@
           "albumReleaseType": "Single",
           "datePublished": "2025-07-28",
           "byArtist": {
-            "@id": "https://stillouder.space/#band"
+            "@id": "https://stilllouder.space/#band"
           }
         },
         "offers": {
@@ -213,10 +213,10 @@
       {
         "@context": "https://schema.org",
         "@type": "MusicGroup",
-        "@id": "https://stillouder.space/#band",
+        "@id": "https://stilllouder.space/#band",
         "name": "Still Louder",
         "alternateName": "Still Louder Band",
-        "url": "https://stillouder.space/",
+        "url": "https://stilllouder.space/",
         "logo": "https://i.imgur.com/CoA13WN.jpg",
         "image": "https://i.imgur.com/CoA13WN.jpg",
         "genre": ["Heavy Metal", "Rock"],
@@ -262,18 +262,18 @@
       {
         "@context": "https://schema.org",
         "@type": "WebSite",
-        "url": "https://stillouder.space/",
+        "url": "https://stilllouder.space/",
         "name": "Still Louder - Official Website",
         "description": "Sitio oficial de Still Louder. Escucha nuestra música en todas las plataformas digitales.",
         "inLanguage": "es",
         "publisher": {
-          "@id": "https://stillouder.space/#band"
+          "@id": "https://stilllouder.space/#band"
         },
         "potentialAction": {
           "@type": "SearchAction",
           "target": {
             "@type": "EntryPoint",
-            "urlTemplate": "https://www.google.com/search?q=site:stillouder.space+{search_term_string}"
+            "urlTemplate": "https://www.google.com/search?q=site:stilllouder.space+{search_term_string}"
           },
           "query-input": "required name=search_term_string"
         }

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,6 @@
 # Robots.txt para Still Louder - Al Vacío
 # Optimizado para SEO y descubrimiento de contenido
-# https://stillouder.space/
+# https://stilllouder.space/
 
 User-agent: *
 Allow: /
@@ -19,7 +19,7 @@ Disallow: /node_modules/
 Disallow: /dist/
 
 # Sitemap
-Sitemap: https://stillouder.space/sitemap.xml
+Sitemap: https://stilllouder.space/sitemap.xml
 
 # Crawl delay para bots no principales
 User-agent: *

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
   <url>
-    <loc>https://stillouder.space/</loc>
+    <loc>https://stilllouder.space/</loc>
     <lastmod>2025-01-11</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
@@ -13,7 +13,7 @@
     </image:image>
   </url>
   <url>
-    <loc>https://stillouder.space/al-vacio-pre-release</loc>
+    <loc>https://stilllouder.space/al-vacio-pre-release</loc>
     <lastmod>2025-01-11</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>


### PR DESCRIPTION
The site URL was missing an 'l' in 'still', causing link previews
(Open Graph, Twitter Cards) to fail when sharing on WhatsApp and
other platforms.