### PR TITLE
feat: add WWWY3 ticket system (M1)

### DIFF
--- a/ticket-system/.env.example
+++ b/ticket-system/.env.example
@@ -1,0 +1,41 @@
+# =============================================================================
+# WWWY3 Ticket System — environment variables
+# =============================================================================
+# Set these in the Vercel project (Settings -> Environment Variables).
+# Everything here is SERVER-ONLY. None of these are exposed to the browser:
+# the frontend never imports them and Vite only inlines vars prefixed VITE_.
+# =============================================================================
+
+# --- Supabase (server-side only) --------------------------------------------
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# --- Email (Resend) ----------------------------------------------------------
+RESEND_API_KEY=
+# From address — domain must be verified in Resend (DKIM/SPF/DMARC).
+EMAIL_FROM="Still Louder <entradas@stilllouder.space>"
+
+# --- QR signing --------------------------------------------------------------
+# Long random secret. Generate with: openssl rand -hex 32
+TICKET_HMAC_SECRET=
+
+# --- Access gates ------------------------------------------------------------
+ADMIN_PASSWORD=
+STAFF_PASSWORD=
+
+# --- CuantoApp (card payments, manual reconciliation) -----------------------
+# Checkout link shown to buyers who choose card. Optional in M1.
+CUANTOAPP_PAYMENT_URL=
+
+# --- Cron ---------------------------------------------------------------------
+# Set this in Vercel so the hourly cleanup cron can authenticate itself.
+# Generate with: openssl rand -hex 16
+CRON_SECRET=
+
+# --- Phase 2: Yappy Comercial (not required for M1) -------------------------
+YAPPY_MERCHANT_ID=
+YAPPY_SECRET_KEY=
+
+# --- Optional ----------------------------------------------------------------
+# Public base URL of this deployment, used to build links in emails.
+PUBLIC_BASE_URL=https://entradas.stilllouder.space

--- a/ticket-system/.gitignore
+++ b/ticket-system/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+.vercel/
+.env
+.env.local
+*.log
+.DS_Store

--- a/ticket-system/README.md
+++ b/ticket-system/README.md
@@ -1,0 +1,176 @@
+# WWWY3 — Sistema de Entradas (Still Louder)
+
+Venta, emisión y validación de entradas para **When We Were Young 3** (Hops, 1 de
+agosto). Construido como app autónoma (React + TypeScript + Vite) con backend en
+**Vercel Serverless Functions** y base de datos **Supabase (Postgres)**. Esta es
+la entrega **M1** (vendible sin Yappy).
+
+> Se construyó como un proyecto independiente dentro del repo (`/ticket-system`)
+> para no tocar el sitio estático existente. Se despliega como un **proyecto Vercel
+> aparte** (sugerido: subdominio `entradas.stilllouder.space`). Ver "Despliegue".
+
+## Superficies
+
+| Ruta        | Quién        | Qué hace                                                        |
+| ----------- | ------------ | --------------------------------------------------------------- |
+| `/entradas` | Público      | Compra: formulario → crea orden → instrucciones de pago.        |
+| `/admin`    | Admin        | Marcar pagado, stats, contadores de preventa, toggle Etapa 2.   |
+| `/validar`  | Staff/puerta | Escáner de QR con resultado verde/rojo + sonido.                |
+
+## Arquitectura
+
+El sistema es **agnóstico al método de pago**. Lo que dispara la emisión de la
+entrada (crear tickets + enviar correo) es **una orden pasando a `paid`**, sin
+importar el origen del pago. Toda esa lógica vive en `api/_lib/issue.ts` y es la
+única rutina que emite. Efectivo y CuantoApp la invocan vía el botón "marcar
+pagado" del admin; Yappy (fase 2) la invocará desde su webhook. **No acoplar la
+emisión a ningún proveedor.**
+
+```
+ticket-system/
+├── api/                      # Vercel serverless functions (TypeScript)
+│   ├── _lib/                 # lógica compartida (NUNCA llega al cliente)
+│   │   ├── env.ts            # acceso validado a variables de entorno
+│   │   ├── supabase.ts       # cliente service-role (bypass RLS)
+│   │   ├── auth.ts           # gates admin/staff (comparación timing-safe)
+│   │   ├── hmac.ts           # firma/verificación del token del QR
+│   │   ├── qr.ts             # render del QR (PNG / data URL)
+│   │   ├── email.ts          # envío con Resend
+│   │   ├── pricing.ts        # precios por tier + ventana de reserva (server-side)
+│   │   └── issue.ts          # rutina de emisión (idempotente, agnóstica al pago)
+│   ├── orders.ts             # POST  /api/orders                (público)
+│   ├── presale/status.ts     # GET   /api/presale/status         (público)
+│   ├── tickets/validate.ts   # POST  /api/tickets/validate       (staff)
+│   ├── tickets/qr.ts         # GET   /api/tickets/qr?t=<token>   (imagen del QR)
+│   ├── admin/orders/index.ts # GET   /api/admin/orders           (admin)
+│   ├── admin/orders/[id]/mark-paid.ts   # POST                   (admin)
+│   ├── admin/orders/cleanup.ts          # POST/GET (admin o cron)
+│   ├── admin/presale/stage2.ts          # POST                   (admin)
+│   └── yappy/webhook.ts      # POST  /api/yappy/webhook          (FASE 2, stub)
+├── src/                      # frontend React
+│   ├── shared/               # api.ts, config.ts, styles.css
+│   ├── entradas/             # flujo de compra
+│   ├── admin/                # panel
+│   └── validar/              # escáner de puerta
+├── supabase/migrations/0001_init.sql   # schema + RPCs atómicas
+├── entradas.html · admin.html · validar.html · index.html
+├── vite.config.ts · vercel.json · .env.example
+```
+
+## Puesta en marcha
+
+### 1. Base de datos (Supabase)
+
+Crea el proyecto en Supabase y corre la migración (SQL Editor o CLI):
+
+```bash
+# opción CLI
+supabase db push   # o pega supabase/migrations/0001_init.sql en el SQL Editor
+```
+
+La migración crea `orders`, `event_config`, `tickets`, los índices, activa RLS
+(sin policies → solo el service-role accede) y define las **RPCs atómicas**:
+`create_order`, `mark_order_paid`, `validate_ticket`, `presale_status`,
+`cleanup_expired_orders`, `mark_order_emailed`.
+
+### 2. Variables de entorno
+
+Copia `.env.example` y complétalo (en Vercel: Settings → Environment Variables).
+Todas son **server-only**; ninguna se expone al navegador.
+
+```
+SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+RESEND_API_KEY, EMAIL_FROM="Still Louder <entradas@stilllouder.space>"
+TICKET_HMAC_SECRET            # openssl rand -hex 32
+ADMIN_PASSWORD, STAFF_PASSWORD
+CRON_SECRET                   # para el cron de limpieza (openssl rand -hex 16)
+CUANTOAPP_PAYMENT_URL         # opcional (link de pago con tarjeta)
+PUBLIC_BASE_URL=https://entradas.stilllouder.space
+```
+
+### 3. Desarrollo local
+
+```bash
+cd ticket-system
+npm install
+npm run dev        # frontend en http://localhost:3100
+```
+
+Para correr las funciones `/api` localmente usa `vercel dev` (Vercel CLI), que
+sirve frontend + funciones juntas y carga las variables del proyecto.
+
+```bash
+npm run typecheck  # tsc para src y api
+npm run build      # build de producción a dist/
+```
+
+## Despliegue (Vercel)
+
+Crea un **segundo proyecto Vercel** apuntando al mismo repo con:
+
+- **Root Directory:** `ticket-system`
+- **Framework Preset:** Vite (build `vite build`, output `dist`)
+- Variables de entorno: las de arriba.
+- Dominio: `entradas.stilllouder.space` (CNAME en el DNS del dominio).
+
+El sitio estático actual (raíz del repo) sigue siendo su propio proyecto Vercel,
+intacto. `vercel.json` aquí define headers de seguridad (CSP, HSTS,
+`Permissions-Policy: camera=(self)` para el escáner) y el **cron horario** que
+ejecuta `/api/admin/orders/cleanup`.
+
+> Alternativa: integrarlo en el proyecto existente bajo `/entradas` y `/validar`.
+> Se eligió el proyecto aparte por la configuración inusual de `publicDir` del
+> sitio actual; migrar es posible moviendo `api/` a la raíz y añadiendo las
+> páginas al build multipágina.
+
+## El QR firmado
+
+Payload: `WWWY3.<ticket_id>.<sig>` con `sig = HMAC_SHA256(ticket_id, TICKET_HMAC_SECRET)`
+truncado a 16 bytes (32 hex). En la puerta:
+
+1. Se **recalcula el HMAC** y se compara (timing-safe). Firma inválida → rechazo
+   inmediato **sin tocar la base** (`result: 'forged'`).
+2. Solo si la firma es válida se ejecuta el `UPDATE` atómico que reclama el ticket.
+
+El secreto vive solo en el servidor; es imposible fabricar entradas válidas sin él.
+
+## Cómo se cumplen los criterios de aceptación
+
+- **Emisión idempotente:** `mark_order_paid` transiciona `pending→paid` una sola
+  vez y crea tickets solo si no existen; el correo se manda solo si `emailed_at`
+  es null y luego se sella. Re-marcar no duplica nada.
+- **Firma inválida → rechazo sin DB:** `verifyToken` corre antes de cualquier
+  consulta (`api/tickets/validate.ts`).
+- **Un QR válido se acepta una vez:** `validate_ticket` hace
+  `update ... where id=$1 and status='valid'`; el segundo intento devuelve 0
+  filas → "ya usada".
+- **Dos escaneos simultáneos:** el `UPDATE` condicional es atómico; solo uno gana.
+- **Admin/staff protegidos:** cada endpoint verifica el password (comparación
+  constante) y devuelve 401 sin él.
+- **Tope de preventa race-safe:** `create_order` toma `... for update` sobre la
+  fila única de `event_config`, serializando los chequeos de cupo. No se vende de
+  más con Etapa 2 inactiva (75) ni activa (150), contando pagadas + pendientes
+  vigentes.
+- **Etapa 2 inmediata:** la capacidad se recalcula en vivo desde `event_config`;
+  el toggle abre 75 cupos al instante.
+- **Pending vencida libera cupo:** `cleanup_expired_orders` (cron horario + botón
+  admin) cancela pendientes vencidas; el conteo de cupo solo cuenta pendientes
+  con `reservation_expires_at > now()`.
+- **Correo desde `entradas@stilllouder.space`:** configurable vía `EMAIL_FROM`
+  (requiere dominio verificado en Resend — DKIM/SPF/DMARC).
+
+## Notas operativas
+
+- **Resend plan gratis:** 3,000/mes y **100/día**. En días pico, un correo por
+  orden (no por entrada) ayuda; vigilar el límite diario.
+- **Ventana de reserva:** efectivo/CuantoApp = 48 h; Yappy = 15 min
+  (`api/_lib/pricing.ts`).
+- **Precios:** se calculan en el servidor a partir de (tier, cantidad); el cliente
+  nunca envía montos.
+
+## Fase 2 — Yappy
+
+`api/yappy/webhook.ts` es el único punto nuevo: tras verificar la firma del
+webhook con `YAPPY_SECRET_KEY` y mapear la referencia a nuestro `orderId`, llama
+`issueOrder()` — la misma rutina que todo lo demás. No agregar lógica de Yappy a
+la emisión. Doc oficial: `yappy.com.pa/comercial/desarrolladores/boton-de-pago-yappy-nueva-integracion/`.

--- a/ticket-system/admin.html
+++ b/ticket-system/admin.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Panel — Still Louder</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/admin/main.tsx"></script>
+  </body>
+</html>

--- a/ticket-system/api/_lib/auth.ts
+++ b/ticket-system/api/_lib/auth.ts
@@ -1,0 +1,49 @@
+import { timingSafeEqual } from 'node:crypto';
+import type { VercelRequest } from '@vercel/node';
+import { env } from './env.js';
+
+/** Constant-time comparison that doesn't leak length via early return. */
+function safeEqual(a: string, b: string): boolean {
+  const bufA = Buffer.from(a);
+  const bufB = Buffer.from(b);
+  if (bufA.length !== bufB.length) {
+    // Still run a comparison to keep timing roughly constant.
+    timingSafeEqual(bufA, bufA);
+    return false;
+  }
+  return timingSafeEqual(bufA, bufB);
+}
+
+/**
+ * Reads the gate password from the request. Accepts either an
+ * `Authorization: Bearer <password>` header or an `x-access-password` header.
+ */
+function readPassword(req: VercelRequest): string {
+  const auth = req.headers['authorization'];
+  if (typeof auth === 'string' && auth.startsWith('Bearer ')) {
+    return auth.slice('Bearer '.length).trim();
+  }
+  const header = req.headers['x-access-password'];
+  if (typeof header === 'string') return header.trim();
+  return '';
+}
+
+export function isAdmin(req: VercelRequest): boolean {
+  const provided = readPassword(req);
+  return provided.length > 0 && safeEqual(provided, env.adminPassword);
+}
+
+export function isStaff(req: VercelRequest): boolean {
+  const provided = readPassword(req);
+  if (provided.length === 0) return false;
+  // Admins can also operate the gate.
+  return safeEqual(provided, env.staffPassword) || safeEqual(provided, env.adminPassword);
+}
+
+/** True when the request is an authenticated Vercel Cron invocation. */
+export function isCron(req: VercelRequest): boolean {
+  const secret = env.cronSecret;
+  if (!secret) return false;
+  const auth = req.headers['authorization'];
+  return typeof auth === 'string' && safeEqual(auth, `Bearer ${secret}`);
+}

--- a/ticket-system/api/_lib/email.ts
+++ b/ticket-system/api/_lib/email.ts
@@ -1,0 +1,80 @@
+import { Resend } from 'resend';
+import { env } from './env.js';
+import { tokenToPngBuffer } from './qr.js';
+import type { Order } from './types.js';
+
+let resend: Resend | null = null;
+function getResend(): Resend {
+  if (!resend) resend = new Resend(env.resendApiKey);
+  return resend;
+}
+
+const TIER_LABEL: Record<string, string> = {
+  preventa: 'Preventa',
+  general: 'General'
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Sends ONE confirmation email per order, with one QR per admission.
+ * Each QR is shown inline via a hosted, stateless image URL (renders in every
+ * mail client and stays scannable on screen) and also attached as a PNG fallback.
+ */
+export async function sendTicketEmail(order: Order, tokens: string[]): Promise<void> {
+  const attachments = await Promise.all(
+    tokens.map(async (token, i) => ({
+      filename: `entrada-${i + 1}.png`,
+      content: await tokenToPngBuffer(token)
+    }))
+  );
+
+  const tierLabel = TIER_LABEL[order.tier] ?? order.tier;
+  const qrBlocks = tokens
+    .map((token, i) => {
+      const src = `${env.publicBaseUrl}/api/tickets/qr?t=${encodeURIComponent(token)}`;
+      return `
+        <div style="margin:24px 0;text-align:center;">
+          <p style="margin:0 0 8px;font-weight:bold;">Admisión ${i + 1} de ${tokens.length}</p>
+          <img src="${src}" width="240" height="240"
+               alt="Código QR de tu entrada ${i + 1}"
+               style="border:1px solid #eee;border-radius:8px;" />
+        </div>`;
+    })
+    .join('');
+
+  const html = `
+    <div style="font-family:Arial,Helvetica,sans-serif;max-width:560px;margin:0 auto;color:#111;">
+      <h1 style="font-size:22px;">¡Tu entrada para WWWY3 está lista! 🎸</h1>
+      <p>Hola ${escapeHtml(order.buyer_name)}, gracias por tu compra.</p>
+      <p style="margin:16px 0;">
+        <strong>Evento:</strong> When We Were Young 3 (Still Louder)<br/>
+        <strong>Lugar:</strong> Hops<br/>
+        <strong>Fecha:</strong> 1 de agosto<br/>
+        <strong>Tipo:</strong> ${escapeHtml(tierLabel)}<br/>
+        <strong>Cantidad:</strong> ${order.quantity} ${order.quantity === 1 ? 'entrada' : 'entradas'}
+      </p>
+      <p>Presenta ${tokens.length === 1 ? 'este código QR' : 'estos códigos QR'} en la puerta.
+         Cada código es válido para una sola admisión.</p>
+      ${qrBlocks}
+      <hr style="border:none;border-top:1px solid #eee;margin:24px 0;" />
+      <p style="font-size:12px;color:#666;">
+        Orden #${order.id}. Si tienes dudas, responde a este correo.
+        Canales oficiales: @stilllouder.
+      </p>
+    </div>`;
+
+  await getResend().emails.send({
+    from: env.emailFrom,
+    to: order.buyer_email,
+    subject: 'Tu entrada para WWWY3 — Still Louder',
+    html,
+    attachments
+  });
+}

--- a/ticket-system/api/_lib/env.ts
+++ b/ticket-system/api/_lib/env.ts
@@ -1,0 +1,46 @@
+// Centralized, validated access to server-side environment variables.
+// Throwing here (rather than reading process.env inline) means a missing
+// secret fails loudly at the edge instead of silently producing broken
+// tokens or unauthenticated requests.
+
+function required(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function optional(name: string, fallback = ''): string {
+  return process.env[name] ?? fallback;
+}
+
+export const env = {
+  get supabaseUrl() {
+    return required('SUPABASE_URL');
+  },
+  get supabaseServiceRoleKey() {
+    return required('SUPABASE_SERVICE_ROLE_KEY');
+  },
+  get resendApiKey() {
+    return required('RESEND_API_KEY');
+  },
+  get emailFrom() {
+    return optional('EMAIL_FROM', 'Still Louder <entradas@stilllouder.space>');
+  },
+  get ticketHmacSecret() {
+    return required('TICKET_HMAC_SECRET');
+  },
+  get adminPassword() {
+    return required('ADMIN_PASSWORD');
+  },
+  get staffPassword() {
+    return required('STAFF_PASSWORD');
+  },
+  get cronSecret() {
+    return optional('CRON_SECRET');
+  },
+  get publicBaseUrl() {
+    return optional('PUBLIC_BASE_URL', 'https://entradas.stilllouder.space');
+  }
+};

--- a/ticket-system/api/_lib/hmac.ts
+++ b/ticket-system/api/_lib/hmac.ts
@@ -1,0 +1,41 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { env } from './env.js';
+
+// QR payload format: WWWY3.<ticket_id>.<sig>
+// sig = first 16 bytes (32 hex chars) of HMAC_SHA256(ticket_id, secret).
+// The signature is what makes counterfeit tickets impossible: without the
+// secret you cannot produce a valid <sig> for any ticket id.
+const PREFIX = 'WWWY3';
+const SIG_HEX_LEN = 32; // 16 bytes
+
+function sign(ticketId: string): string {
+  return createHmac('sha256', env.ticketHmacSecret)
+    .update(ticketId)
+    .digest('hex')
+    .slice(0, SIG_HEX_LEN);
+}
+
+export function makeToken(ticketId: string): string {
+  return `${PREFIX}.${ticketId}.${sign(ticketId)}`;
+}
+
+/**
+ * Verifies a scanned token WITHOUT touching the database. Returns the ticket id
+ * only when the signature is cryptographically valid; otherwise null. Callers
+ * must treat null as an immediate rejection (forged / corrupt code).
+ */
+export function verifyToken(token: string): string | null {
+  if (typeof token !== 'string') return null;
+  const parts = token.trim().split('.');
+  if (parts.length !== 3) return null;
+  const [prefix, ticketId, sig] = parts;
+  if (prefix !== PREFIX || !ticketId || !sig) return null;
+
+  const expected = sign(ticketId);
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return null;
+  if (!timingSafeEqual(a, b)) return null;
+
+  return ticketId;
+}

--- a/ticket-system/api/_lib/http.ts
+++ b/ticket-system/api/_lib/http.ts
@@ -1,0 +1,46 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+
+export function sendJson(res: VercelResponse, status: number, body: unknown): void {
+  res.status(status).setHeader('Content-Type', 'application/json; charset=utf-8');
+  res.send(JSON.stringify(body));
+}
+
+export function methodNotAllowed(res: VercelResponse, allowed: string[]): void {
+  res.setHeader('Allow', allowed.join(', '));
+  sendJson(res, 405, { error: 'method_not_allowed' });
+}
+
+/**
+ * Vercel parses JSON bodies automatically, but tolerate a raw string body too
+ * (e.g. when content-type is missing). Returns {} for empty bodies.
+ */
+export function parseBody<T = Record<string, unknown>>(req: VercelRequest): T {
+  const body = req.body;
+  if (body == null || body === '') return {} as T;
+  if (typeof body === 'string') {
+    try {
+      return JSON.parse(body) as T;
+    } catch {
+      return {} as T;
+    }
+  }
+  return body as T;
+}
+
+/** Wraps a handler so any thrown error becomes a 500 instead of a crash. */
+export function withErrorHandling(
+  handler: (req: VercelRequest, res: VercelResponse) => Promise<void> | void
+) {
+  return async (req: VercelRequest, res: VercelResponse): Promise<void> => {
+    try {
+      await handler(req, res);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'unknown_error';
+      // Don't leak internals to clients; log for server-side debugging.
+      console.error('[api error]', message, err);
+      if (!res.headersSent) {
+        sendJson(res, 500, { error: 'internal_error' });
+      }
+    }
+  };
+}

--- a/ticket-system/api/_lib/issue.ts
+++ b/ticket-system/api/_lib/issue.ts
@@ -1,0 +1,71 @@
+import { getSupabase } from './supabase.js';
+import { makeToken } from './hmac.js';
+import { sendTicketEmail } from './email.js';
+import type { Order, Ticket } from './types.js';
+
+export class IssueError extends Error {
+  constructor(
+    public code: 'order_not_found' | 'order_cancelled' | 'db_error',
+    message: string
+  ) {
+    super(message);
+  }
+}
+
+export interface IssueResult {
+  order: Order;
+  ticketCount: number;
+  emailed: boolean;
+}
+
+/**
+ * The single, payment-method-agnostic issuance routine. Whatever marks an order
+ * paid (admin button, cash, CuantoApp, future Yappy webhook) funnels here.
+ *
+ * Idempotent on every axis:
+ *  - mark_order_paid (RPC) only transitions pending->paid once and only creates
+ *    tickets when none exist.
+ *  - the email is only sent when orders.emailed_at is null, then stamped, so a
+ *    retry after a transient email failure resends at most once and a re-mark
+ *    never double-sends.
+ */
+export async function issueOrder(orderId: string, paymentRef?: string | null): Promise<IssueResult> {
+  const supabase = getSupabase();
+
+  const { data: order, error } = await supabase
+    .rpc('mark_order_paid', { p_order_id: orderId, p_payment_ref: paymentRef ?? null })
+    .single<Order>();
+
+  if (error) {
+    if (error.message.includes('ORDER_NOT_FOUND')) {
+      throw new IssueError('order_not_found', 'Order not found');
+    }
+    if (error.message.includes('ORDER_CANCELLED')) {
+      throw new IssueError('order_cancelled', 'Order is cancelled and cannot be paid');
+    }
+    throw new IssueError('db_error', error.message);
+  }
+  if (!order) {
+    throw new IssueError('order_not_found', 'Order not found');
+  }
+
+  const { data: tickets, error: ticketsError } = await supabase
+    .from('tickets')
+    .select('id')
+    .eq('order_id', orderId)
+    .order('created_at', { ascending: true });
+
+  if (ticketsError) throw new IssueError('db_error', ticketsError.message);
+
+  const ticketRows = (tickets ?? []) as Pick<Ticket, 'id'>[];
+  const tokens = ticketRows.map((t) => makeToken(t.id));
+
+  let emailed = false;
+  if (!order.emailed_at && tokens.length > 0) {
+    await sendTicketEmail(order, tokens);
+    await supabase.rpc('mark_order_emailed', { p_order_id: orderId });
+    emailed = true;
+  }
+
+  return { order, ticketCount: tokens.length, emailed };
+}

--- a/ticket-system/api/_lib/pricing.ts
+++ b/ticket-system/api/_lib/pricing.ts
@@ -1,0 +1,28 @@
+import type { PaymentMethod, Tier } from './types.js';
+
+// Prices are authoritative on the server. The client never sends an amount;
+// we derive total_cents here from (tier, quantity) so a tampered request can't
+// change what's owed.
+const TIER_PRICE_CENTS: Record<Tier, number> = {
+  preventa: 600, // $6 presale
+  general: 800 // $8 day-of / general
+};
+
+export function priceFor(tier: Tier, quantity: number): number {
+  return TIER_PRICE_CENTS[tier] * quantity;
+}
+
+// How long a pending order holds its presale cupo before cleanup frees it.
+// Manual methods (cash / CuantoApp) need a generous window because
+// reconciliation is human; Yappy confirms instantly so it can be short.
+const RESERVATION_MINUTES: Record<PaymentMethod, number> = {
+  cash: 48 * 60,
+  cuantoapp: 48 * 60,
+  yappy: 15
+};
+
+export function reservationMinutesFor(method: PaymentMethod): number {
+  return RESERVATION_MINUTES[method];
+}
+
+export const MAX_QUANTITY_PER_ORDER = 10;

--- a/ticket-system/api/_lib/qr.ts
+++ b/ticket-system/api/_lib/qr.ts
@@ -1,0 +1,21 @@
+import QRCode from 'qrcode';
+
+// Render a signed token into a PNG buffer (for email attachments) or a data
+// URL (for inline rendering). Error correction level 'M' balances density and
+// resilience to phone-camera scanning at the door.
+export async function tokenToPngBuffer(token: string): Promise<Buffer> {
+  return QRCode.toBuffer(token, {
+    errorCorrectionLevel: 'M',
+    type: 'png',
+    margin: 2,
+    width: 512
+  });
+}
+
+export async function tokenToDataUrl(token: string): Promise<string> {
+  return QRCode.toDataURL(token, {
+    errorCorrectionLevel: 'M',
+    margin: 2,
+    width: 512
+  });
+}

--- a/ticket-system/api/_lib/supabase.ts
+++ b/ticket-system/api/_lib/supabase.ts
@@ -1,0 +1,15 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { env } from './env.js';
+
+// Service-role client. Bypasses RLS — must NEVER be shipped to the browser.
+// Lazily instantiated so importing this module doesn't require env at build.
+let client: SupabaseClient | null = null;
+
+export function getSupabase(): SupabaseClient {
+  if (!client) {
+    client = createClient(env.supabaseUrl, env.supabaseServiceRoleKey, {
+      auth: { persistSession: false, autoRefreshToken: false }
+    });
+  }
+  return client;
+}

--- a/ticket-system/api/_lib/types.ts
+++ b/ticket-system/api/_lib/types.ts
@@ -1,0 +1,43 @@
+export type Tier = 'preventa' | 'general';
+export type PaymentMethod = 'yappy' | 'cuantoapp' | 'cash';
+export type OrderStatus = 'pending' | 'paid' | 'cancelled';
+export type TicketStatus = 'valid' | 'used' | 'void';
+
+export interface Order {
+  id: string;
+  buyer_name: string;
+  buyer_email: string;
+  buyer_phone: string | null;
+  tier: Tier;
+  quantity: number;
+  total_cents: number;
+  payment_method: PaymentMethod;
+  payment_ref: string | null;
+  status: OrderStatus;
+  created_at: string;
+  paid_at: string | null;
+  reservation_expires_at: string | null;
+  emailed_at: string | null;
+}
+
+export interface Ticket {
+  id: string;
+  order_id: string;
+  tier: Tier;
+  status: TicketStatus;
+  used_at: string | null;
+  used_by: string | null;
+  created_at: string;
+}
+
+export interface PresaleStatus {
+  capacity: number;
+  paid_count: number;
+  pending_count: number;
+  committed: number;
+  available: number;
+  stage2_active: boolean;
+  sold_out: boolean;
+}
+
+export type ValidateResult = 'valid' | 'already_used' | 'void' | 'not_found';

--- a/ticket-system/api/admin/orders/[id]/mark-paid.ts
+++ b/ticket-system/api/admin/orders/[id]/mark-paid.ts
@@ -1,0 +1,37 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { isAdmin } from '../../../_lib/auth.js';
+import { methodNotAllowed, parseBody, sendJson, withErrorHandling } from '../../../_lib/http.js';
+import { issueOrder, IssueError } from '../../../_lib/issue.js';
+
+interface MarkPaidBody {
+  payment_ref?: string;
+}
+
+// POST /api/admin/orders/:id/mark-paid  -> marks paid and triggers issuance
+// (tickets + email). Idempotent: re-marking never duplicates tickets or emails.
+export default withErrorHandling(async (req: VercelRequest, res: VercelResponse) => {
+  if (req.method !== 'POST') return methodNotAllowed(res, ['POST']);
+  if (!isAdmin(req)) return sendJson(res, 401, { error: 'unauthorized' });
+
+  const id = typeof req.query.id === 'string' ? req.query.id : '';
+  if (!id) return sendJson(res, 400, { error: 'missing_order_id' });
+
+  const body = parseBody<MarkPaidBody>(req);
+  const paymentRef = (body.payment_ref ?? '').trim() || null;
+
+  try {
+    const result = await issueOrder(id, paymentRef);
+    return sendJson(res, 200, {
+      orderId: result.order.id,
+      status: result.order.status,
+      ticketCount: result.ticketCount,
+      emailed: result.emailed
+    });
+  } catch (err) {
+    if (err instanceof IssueError) {
+      if (err.code === 'order_not_found') return sendJson(res, 404, { error: 'order_not_found' });
+      if (err.code === 'order_cancelled') return sendJson(res, 409, { error: 'order_cancelled' });
+    }
+    throw err;
+  }
+});

--- a/ticket-system/api/admin/orders/cleanup.ts
+++ b/ticket-system/api/admin/orders/cleanup.ts
@@ -1,0 +1,22 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { getSupabase } from '../../_lib/supabase.js';
+import { isAdmin, isCron } from '../../_lib/auth.js';
+import { methodNotAllowed, sendJson, withErrorHandling } from '../../_lib/http.js';
+
+// POST /api/admin/orders/cleanup -> cancels expired pending orders, freeing
+// their reserved presale cupo. Runs on an hourly Vercel Cron (authenticated via
+// CRON_SECRET) and is also callable manually from the admin panel.
+export default withErrorHandling(async (req: VercelRequest, res: VercelResponse) => {
+  // Cron uses GET; the admin button uses POST.
+  if (req.method !== 'POST' && req.method !== 'GET') {
+    return methodNotAllowed(res, ['POST', 'GET']);
+  }
+  if (!isAdmin(req) && !isCron(req)) {
+    return sendJson(res, 401, { error: 'unauthorized' });
+  }
+
+  const { data, error } = await getSupabase().rpc('cleanup_expired_orders');
+  if (error) throw new Error(`cleanup failed: ${error.message}`);
+
+  return sendJson(res, 200, { cancelled: data ?? 0 });
+});

--- a/ticket-system/api/admin/orders/index.ts
+++ b/ticket-system/api/admin/orders/index.ts
@@ -1,0 +1,64 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { getSupabase } from '../../_lib/supabase.js';
+import { isAdmin } from '../../_lib/auth.js';
+import { methodNotAllowed, sendJson, withErrorHandling } from '../../_lib/http.js';
+import type { Order, PresaleStatus } from '../../_lib/types.js';
+
+// GET /api/admin/orders?q=&status=  -> order list + sales stats. Admin-gated.
+export default withErrorHandling(async (req: VercelRequest, res: VercelResponse) => {
+  if (req.method !== 'GET') return methodNotAllowed(res, ['GET']);
+  if (!isAdmin(req)) return sendJson(res, 401, { error: 'unauthorized' });
+
+  const supabase = getSupabase();
+  const q = typeof req.query.q === 'string' ? req.query.q.trim() : '';
+  const status = typeof req.query.status === 'string' ? req.query.status : '';
+
+  let query = supabase
+    .from('orders')
+    .select('*')
+    .order('created_at', { ascending: false })
+    .limit(200);
+
+  if (status && ['pending', 'paid', 'cancelled'].includes(status)) {
+    query = query.eq('status', status);
+  }
+  if (q) {
+    const safe = q.replace(/[%,]/g, '');
+    query = query.or(`buyer_name.ilike.%${safe}%,buyer_email.ilike.%${safe}%`);
+  }
+
+  const { data: orders, error } = await query;
+  if (error) throw new Error(`orders query failed: ${error.message}`);
+
+  // --- Stats ---
+  const { data: presale, error: presaleErr } = await supabase
+    .rpc('presale_status')
+    .single<PresaleStatus>();
+  if (presaleErr) throw new Error(`presale_status failed: ${presaleErr.message}`);
+
+  const { data: paidOrders, error: paidErr } = await supabase
+    .from('orders')
+    .select('tier, quantity, total_cents')
+    .eq('status', 'paid');
+  if (paidErr) throw new Error(`stats query failed: ${paidErr.message}`);
+
+  const paid = (paidOrders ?? []) as Pick<Order, 'tier' | 'quantity' | 'total_cents'>[];
+  const stats = {
+    presale: {
+      capacity: presale!.capacity,
+      paid: presale!.paid_count,
+      pending: presale!.pending_count,
+      available: presale!.available,
+      stage2Active: presale!.stage2_active,
+      soldOut: presale!.sold_out
+    },
+    generalPaid: paid
+      .filter((o) => o.tier === 'general')
+      .reduce((sum, o) => sum + o.quantity, 0),
+    totalTicketsPaid: paid.reduce((sum, o) => sum + o.quantity, 0),
+    revenueCents: paid.reduce((sum, o) => sum + o.total_cents, 0)
+  };
+
+  res.setHeader('Cache-Control', 'no-store');
+  return sendJson(res, 200, { orders: orders ?? [], stats });
+});

--- a/ticket-system/api/admin/presale/stage2.ts
+++ b/ticket-system/api/admin/presale/stage2.ts
@@ -1,0 +1,32 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { getSupabase } from '../../_lib/supabase.js';
+import { isAdmin } from '../../_lib/auth.js';
+import { methodNotAllowed, parseBody, sendJson, withErrorHandling } from '../../_lib/http.js';
+
+interface Stage2Body {
+  active?: boolean;
+}
+
+// POST /api/admin/presale/stage2 { active } -> toggles the second presale stage.
+// Activating opens 75 additional cupos immediately (capacity is recomputed live
+// from event_config on every check).
+export default withErrorHandling(async (req: VercelRequest, res: VercelResponse) => {
+  if (req.method !== 'POST') return methodNotAllowed(res, ['POST']);
+  if (!isAdmin(req)) return sendJson(res, 401, { error: 'unauthorized' });
+
+  const body = parseBody<Stage2Body>(req);
+  if (typeof body.active !== 'boolean') {
+    return sendJson(res, 400, { error: 'invalid_active' });
+  }
+
+  const { data, error } = await getSupabase()
+    .from('event_config')
+    .update({ presale_stage2_active: body.active, updated_at: new Date().toISOString() })
+    .eq('id', 1)
+    .select('presale_stage2_active')
+    .single<{ presale_stage2_active: boolean }>();
+
+  if (error) throw new Error(`stage2 toggle failed: ${error.message}`);
+
+  return sendJson(res, 200, { stage2Active: data!.presale_stage2_active });
+});

--- a/ticket-system/api/orders.ts
+++ b/ticket-system/api/orders.ts
@@ -1,0 +1,106 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { getSupabase } from './_lib/supabase.js';
+import { methodNotAllowed, parseBody, sendJson, withErrorHandling } from './_lib/http.js';
+import { MAX_QUANTITY_PER_ORDER, priceFor, reservationMinutesFor } from './_lib/pricing.js';
+import type { Order, PaymentMethod, Tier } from './_lib/types.js';
+
+const TIERS: Tier[] = ['preventa', 'general'];
+const METHODS: PaymentMethod[] = ['yappy', 'cuantoapp', 'cash'];
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface CreateOrderBody {
+  buyer_name?: string;
+  buyer_email?: string;
+  buyer_phone?: string;
+  tier?: string;
+  quantity?: number;
+  payment_method?: string;
+}
+
+function paymentInstructions(method: PaymentMethod, totalCents: number) {
+  const amount = `$${(totalCents / 100).toFixed(2)}`;
+  switch (method) {
+    case 'cuantoapp':
+      return {
+        method,
+        amount,
+        // Operator pastes the CuantoApp checkout link here via env.
+        link: process.env.CUANTOAPP_PAYMENT_URL ?? '',
+        note: 'Paga con tarjeta a través del enlace de CuantoApp. Tu entrada se envía al confirmar el pago.'
+      };
+    case 'cash':
+      return {
+        method,
+        amount,
+        note: 'Coordina el pago en efectivo por nuestros canales oficiales (@stilllouder). Reservamos tu cupo por 48 horas.'
+      };
+    case 'yappy':
+      return {
+        method,
+        amount,
+        note: 'El pago con Yappy estará disponible próximamente.'
+      };
+  }
+}
+
+export default withErrorHandling(async (req: VercelRequest, res: VercelResponse) => {
+  if (req.method !== 'POST') return methodNotAllowed(res, ['POST']);
+
+  const body = parseBody<CreateOrderBody>(req);
+  const buyerName = (body.buyer_name ?? '').trim();
+  const buyerEmail = (body.buyer_email ?? '').trim().toLowerCase();
+  const buyerPhone = (body.buyer_phone ?? '').trim() || null;
+  const tier = body.tier as Tier;
+  const method = body.payment_method as PaymentMethod;
+  const quantity = Number(body.quantity);
+
+  // --- Validation ---
+  if (buyerName.length < 2) {
+    return sendJson(res, 400, { error: 'invalid_name' });
+  }
+  if (!EMAIL_RE.test(buyerEmail)) {
+    return sendJson(res, 400, { error: 'invalid_email' });
+  }
+  if (!TIERS.includes(tier)) {
+    return sendJson(res, 400, { error: 'invalid_tier' });
+  }
+  if (!METHODS.includes(method)) {
+    return sendJson(res, 400, { error: 'invalid_payment_method' });
+  }
+  if (!Number.isInteger(quantity) || quantity < 1 || quantity > MAX_QUANTITY_PER_ORDER) {
+    return sendJson(res, 400, { error: 'invalid_quantity' });
+  }
+
+  // Total is computed server-side; the client cannot influence the price.
+  const totalCents = priceFor(tier, quantity);
+  const reservationMinutes = reservationMinutesFor(method);
+
+  const { data: order, error } = await getSupabase()
+    .rpc('create_order', {
+      p_buyer_name: buyerName,
+      p_buyer_email: buyerEmail,
+      p_buyer_phone: buyerPhone,
+      p_tier: tier,
+      p_quantity: quantity,
+      p_total_cents: totalCents,
+      p_payment_method: method,
+      p_reservation_minutes: reservationMinutes
+    })
+    .single<Order>();
+
+  if (error) {
+    if (error.message.includes('PRESALE_SOLD_OUT')) {
+      return sendJson(res, 409, { error: 'presale_sold_out' });
+    }
+    throw new Error(`create_order failed: ${error.message}`);
+  }
+
+  return sendJson(res, 201, {
+    orderId: order!.id,
+    tier: order!.tier,
+    quantity: order!.quantity,
+    totalCents: order!.total_cents,
+    reservationExpiresAt: order!.reservation_expires_at,
+    payment: paymentInstructions(method, totalCents)
+  });
+});

--- a/ticket-system/api/presale/status.ts
+++ b/ticket-system/api/presale/status.ts
@@ -1,0 +1,21 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { getSupabase } from '../_lib/supabase.js';
+import { methodNotAllowed, sendJson, withErrorHandling } from '../_lib/http.js';
+import type { PresaleStatus } from '../_lib/types.js';
+
+// Public: powers the "quedan N" / "preventa agotada" indicator on /entradas.
+export default withErrorHandling(async (req: VercelRequest, res: VercelResponse) => {
+  if (req.method !== 'GET') return methodNotAllowed(res, ['GET']);
+
+  const { data, error } = await getSupabase().rpc('presale_status').single<PresaleStatus>();
+  if (error) throw new Error(`presale_status failed: ${error.message}`);
+
+  // Don't expose raw paid/pending counts publicly; just what the UI needs.
+  res.setHeader('Cache-Control', 'no-store');
+  return sendJson(res, 200, {
+    available: data!.available,
+    capacity: data!.capacity,
+    stage2Active: data!.stage2_active,
+    soldOut: data!.sold_out
+  });
+});

--- a/ticket-system/api/tickets/qr.ts
+++ b/ticket-system/api/tickets/qr.ts
@@ -1,0 +1,23 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { methodNotAllowed, sendJson, withErrorHandling } from '../_lib/http.js';
+import { verifyToken } from '../_lib/hmac.js';
+import { tokenToPngBuffer } from '../_lib/qr.js';
+
+// Stateless QR image for a signed token. Used as the inline <img src> in the
+// confirmation email so the code renders in every mail client. Verifies the
+// HMAC before rendering (so it can't be abused as an arbitrary QR generator)
+// but never touches the database.
+export default withErrorHandling(async (req: VercelRequest, res: VercelResponse) => {
+  if (req.method !== 'GET') return methodNotAllowed(res, ['GET']);
+
+  const raw = req.query.t;
+  const token = Array.isArray(raw) ? raw[0] : raw;
+  if (!token || !verifyToken(token)) {
+    return sendJson(res, 400, { error: 'invalid_token' });
+  }
+
+  const png = await tokenToPngBuffer(token);
+  res.setHeader('Content-Type', 'image/png');
+  res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+  res.status(200).send(png);
+});

--- a/ticket-system/api/tickets/validate.ts
+++ b/ticket-system/api/tickets/validate.ts
@@ -1,0 +1,54 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { getSupabase } from '../_lib/supabase.js';
+import { isStaff } from '../_lib/auth.js';
+import { methodNotAllowed, parseBody, sendJson, withErrorHandling } from '../_lib/http.js';
+import { verifyToken } from '../_lib/hmac.js';
+import type { ValidateResult } from '../_lib/types.js';
+
+interface ValidateBody {
+  token?: string;
+  station?: string;
+}
+
+interface ValidateRow {
+  result: ValidateResult;
+  ticket_id: string | null;
+  tier: string | null;
+  used_at: string | null;
+  used_by: string | null;
+  buyer_name: string | null;
+}
+
+// Gate scanner endpoint. Staff-gated. Two-stage defense:
+//  1. Verify the HMAC locally — a forged code is rejected WITHOUT a DB hit.
+//  2. Only then run the atomic validate_ticket RPC, which flips valid->used in
+//     a single statement so concurrent scans of the same code can't both win.
+export default withErrorHandling(async (req: VercelRequest, res: VercelResponse) => {
+  if (req.method !== 'POST') return methodNotAllowed(res, ['POST']);
+  if (!isStaff(req)) return sendJson(res, 401, { error: 'unauthorized' });
+
+  const body = parseBody<ValidateBody>(req);
+  const token = (body.token ?? '').trim();
+  const station = (body.station ?? 'gate').slice(0, 64);
+
+  // Stage 1: signature check, no database access.
+  const ticketId = verifyToken(token);
+  if (!ticketId) {
+    return sendJson(res, 200, { result: 'forged' });
+  }
+
+  // Stage 2: atomic claim.
+  const { data, error } = await getSupabase()
+    .rpc('validate_ticket', { p_ticket_id: ticketId, p_used_by: station })
+    .single<ValidateRow>();
+
+  if (error) throw new Error(`validate_ticket failed: ${error.message}`);
+
+  return sendJson(res, 200, {
+    result: data!.result, // 'valid' | 'already_used' | 'void' | 'not_found'
+    tier: data!.tier,
+    usedAt: data!.used_at,
+    usedBy: data!.used_by,
+    buyerName: data!.buyer_name
+  });
+});

--- a/ticket-system/api/yappy/webhook.ts
+++ b/ticket-system/api/yappy/webhook.ts
@@ -1,0 +1,50 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { methodNotAllowed, parseBody, sendJson, withErrorHandling } from '../_lib/http.js';
+import { issueOrder } from '../_lib/issue.js';
+
+// =============================================================================
+// PHASE 2 — Yappy Comercial webhook (stub)
+// =============================================================================
+// This is the ONLY new code Yappy should require. The issuance routine is
+// payment-agnostic (see api/_lib/issue.ts), so a confirmed Yappy payment is
+// just another caller of issueOrder() — exactly like the admin "mark paid"
+// button. Do NOT add Yappy-specific logic into issuance.
+//
+// TODO (when Yappy Comercial is approved):
+//  1. Verify the webhook signature/HMAC using YAPPY_SECRET_KEY against the raw
+//     body (reject anything that doesn't validate — this is the trust boundary).
+//  2. Map the Yappy order/transaction reference to our internal orderId
+//     (store the Yappy ref in orders.payment_ref when the order is created via
+//     the Yappy button flow).
+//  3. Only act on a "confirmed/paid" status.
+// Endpoints & payloads: yappy.com.pa/comercial/desarrolladores/boton-de-pago-yappy-nueva-integracion/
+// =============================================================================
+
+interface YappyWebhookBody {
+  orderId?: string;
+  status?: string;
+  transactionId?: string;
+}
+
+export default withErrorHandling(async (req: VercelRequest, res: VercelResponse) => {
+  if (req.method !== 'POST') return methodNotAllowed(res, ['POST']);
+
+  // Until Yappy is approved and signature verification is wired up, refuse to
+  // act. Returning 501 makes it obvious this path is not live yet.
+  if (!process.env.YAPPY_SECRET_KEY) {
+    return sendJson(res, 501, { error: 'yappy_not_configured' });
+  }
+
+  // --- Placeholder for signature verification (see TODO #1) ---
+  // const valid = verifyYappySignature(rawBody, req.headers, env.yappySecretKey);
+  // if (!valid) return sendJson(res, 401, { error: 'invalid_signature' });
+
+  const body = parseBody<YappyWebhookBody>(req);
+  if (!body.orderId || body.status !== 'paid') {
+    return sendJson(res, 200, { ignored: true });
+  }
+
+  // Same issuance routine as every other payment method.
+  await issueOrder(body.orderId, body.transactionId ?? null);
+  return sendJson(res, 200, { ok: true });
+});

--- a/ticket-system/entradas.html
+++ b/ticket-system/entradas.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Entradas — When We Were Young 3 | Still Louder</title>
+    <meta
+      name="description"
+      content="Compra tus entradas para When We Were Young 3 de Still Louder en Hops, 1 de agosto."
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/entradas/main.tsx"></script>
+  </body>
+</html>

--- a/ticket-system/index.html
+++ b/ticket-system/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Still Louder — Entradas</title>
+    <meta http-equiv="refresh" content="0; url=/entradas" />
+  </head>
+  <body>
+    <p>Redirigiendo a <a href="/entradas">entradas</a>…</p>
+  </body>
+</html>

--- a/ticket-system/package.json
+++ b/ticket-system/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "wwwy3-ticket-system",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Still Louder — WWWY3 ticket sales, issuance and gate validation",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.api.json --noEmit"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.45.4",
+    "qrcode": "^1.5.4",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "resend": "^4.0.1"
+  },
+  "devDependencies": {
+    "@types/qrcode": "^1.5.5",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vercel/node": "^3.2.24",
+    "@vitejs/plugin-react": "^4.3.3",
+    "html5-qrcode": "^2.3.8",
+    "typescript": "^5.6.3",
+    "vite": "^5.4.10"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/ticket-system/src/admin/App.tsx
+++ b/ticket-system/src/admin/App.tsx
@@ -1,0 +1,302 @@
+import { useCallback, useEffect, useState } from 'react';
+import {
+  cleanupExpired,
+  fetchAdminOrders,
+  markOrderPaid,
+  toggleStage2,
+  type AdminOrder,
+  type AdminStats
+} from '../shared/api';
+
+const STORAGE_KEY = 'wwwy3_admin_pw';
+
+export default function App() {
+  const [password, setPassword] = useState(() => sessionStorage.getItem(STORAGE_KEY) ?? '');
+  const [authed, setAuthed] = useState(false);
+
+  if (!authed) {
+    return (
+      <Gate
+        password={password}
+        setPassword={setPassword}
+        onSuccess={() => {
+          sessionStorage.setItem(STORAGE_KEY, password);
+          setAuthed(true);
+        }}
+      />
+    );
+  }
+  return <Dashboard password={password} onLogout={() => {
+    sessionStorage.removeItem(STORAGE_KEY);
+    setPassword('');
+    setAuthed(false);
+  }} />;
+}
+
+function Gate({
+  password,
+  setPassword,
+  onSuccess
+}: {
+  password: string;
+  setPassword: (v: string) => void;
+  onSuccess: () => void;
+}) {
+  const [error, setError] = useState('');
+  const [checking, setChecking] = useState(false);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setChecking(true);
+    setError('');
+    try {
+      // A successful listing call doubles as a password check.
+      await fetchAdminOrders(password);
+      onSuccess();
+    } catch {
+      setError('Contraseña incorrecta.');
+    } finally {
+      setChecking(false);
+    }
+  }
+
+  return (
+    <div className="container" style={{ maxWidth: 400 }}>
+      <form className="card" onSubmit={submit}>
+        <h1 style={{ marginTop: 0 }}>Panel de admin</h1>
+        <label htmlFor="pw">Contraseña</label>
+        <input
+          id="pw"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          autoFocus
+        />
+        {error && <div className="alert alert--error">{error}</div>}
+        <button type="submit" disabled={checking} style={{ width: '100%' }}>
+          {checking ? 'Verificando…' : 'Entrar'}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+function Dashboard({ password, onLogout }: { password: string; onLogout: () => void }) {
+  const [orders, setOrders] = useState<AdminOrder[]>([]);
+  const [stats, setStats] = useState<AdminStats | null>(null);
+  const [q, setQ] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [busyId, setBusyId] = useState('');
+  const [message, setMessage] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetchAdminOrders(password, { q, status: statusFilter });
+      setOrders(data.orders);
+      setStats(data.stats);
+    } catch {
+      setMessage('Error cargando órdenes.');
+    } finally {
+      setLoading(false);
+    }
+  }, [password, q, statusFilter]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function handleMarkPaid(order: AdminOrder) {
+    const ref = window.prompt(
+      `Marcar como PAGADA la orden de ${order.buyer_name} (${order.quantity} x ${order.tier}).\nReferencia de pago (opcional):`,
+      ''
+    );
+    if (ref === null) return; // cancelled
+    setBusyId(order.id);
+    setMessage('');
+    try {
+      const result = await markOrderPaid(password, order.id, ref || undefined);
+      setMessage(
+        result.emailed
+          ? `✓ Pagada. ${result.ticketCount} entrada(s) emitidas y correo enviado.`
+          : `✓ Pagada. ${result.ticketCount} entrada(s) (correo ya se había enviado).`
+      );
+      await load();
+    } catch (err) {
+      const code = (err as Error & { code?: string }).code;
+      setMessage(code === 'order_cancelled' ? 'La orden está cancelada.' : 'Error al marcar pagada.');
+    } finally {
+      setBusyId('');
+    }
+  }
+
+  async function handleStage2(active: boolean) {
+    if (!window.confirm(active ? '¿Activar Etapa 2 (75 cupos extra)?' : '¿Desactivar Etapa 2?')) return;
+    try {
+      await toggleStage2(password, active);
+      await load();
+    } catch {
+      setMessage('Error al cambiar la Etapa 2.');
+    }
+  }
+
+  async function handleCleanup() {
+    if (!window.confirm('¿Cancelar todas las órdenes pendientes vencidas y liberar su cupo?')) return;
+    try {
+      const { cancelled } = await cleanupExpired(password);
+      setMessage(`${cancelled} orden(es) vencida(s) cancelada(s).`);
+      await load();
+    } catch {
+      setMessage('Error en la limpieza.');
+    }
+  }
+
+  return (
+    <div className="container" style={{ maxWidth: 980 }}>
+      <header style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <h1>Panel WWWY3</h1>
+        <button className="secondary" onClick={onLogout}>
+          Salir
+        </button>
+      </header>
+
+      {stats && (
+        <div className="card" style={{ marginBottom: 20 }}>
+          <h2 style={{ marginTop: 0 }}>Preventa</h2>
+          <div className="stat-grid">
+            <div className="stat">
+              <div className="stat__value">{stats.presale.paid}</div>
+              <div className="stat__label">Pagadas</div>
+            </div>
+            <div className="stat">
+              <div className="stat__value">{stats.presale.pending}</div>
+              <div className="stat__label">Pendientes</div>
+            </div>
+            <div className="stat">
+              <div className="stat__value">{stats.presale.available}</div>
+              <div className="stat__label">Disponibles</div>
+            </div>
+            <div className="stat">
+              <div className="stat__value">{stats.presale.capacity}</div>
+              <div className="stat__label">Capacidad</div>
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'center' }}>
+            <span>
+              Etapa 2:{' '}
+              <strong>{stats.presale.stage2Active ? 'ACTIVA' : 'inactiva'}</strong>
+            </span>
+            {stats.presale.stage2Active ? (
+              <button className="secondary" onClick={() => handleStage2(false)}>
+                Desactivar Etapa 2
+              </button>
+            ) : (
+              <button onClick={() => handleStage2(true)}>Activar Etapa 2 (+75)</button>
+            )}
+            <button className="secondary" onClick={handleCleanup}>
+              Limpiar pendientes vencidas
+            </button>
+          </div>
+
+          <hr style={{ borderColor: 'var(--border)', margin: '16px 0' }} />
+          <div className="stat-grid">
+            <div className="stat">
+              <div className="stat__value">{stats.generalPaid}</div>
+              <div className="stat__label">General pagadas</div>
+            </div>
+            <div className="stat">
+              <div className="stat__value">{stats.totalTicketsPaid}</div>
+              <div className="stat__label">Entradas totales</div>
+            </div>
+            <div className="stat">
+              <div className="stat__value">${(stats.revenueCents / 100).toFixed(0)}</div>
+              <div className="stat__label">Ingresos</div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {message && <div className="alert alert--success">{message}</div>}
+
+      <div className="card">
+        <div style={{ display: 'flex', gap: 12, marginBottom: 16, flexWrap: 'wrap' }}>
+          <input
+            placeholder="Buscar por nombre o correo…"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            style={{ flex: 1, marginBottom: 0, minWidth: 200 }}
+          />
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            style={{ width: 160, marginBottom: 0 }}
+          >
+            <option value="">Todos</option>
+            <option value="pending">Pendientes</option>
+            <option value="paid">Pagadas</option>
+            <option value="cancelled">Canceladas</option>
+          </select>
+          <button className="secondary" onClick={load}>
+            Refrescar
+          </button>
+        </div>
+
+        {loading ? (
+          <p className="muted">Cargando…</p>
+        ) : (
+          <div style={{ overflowX: 'auto' }}>
+            <table>
+              <thead>
+                <tr>
+                  <th>Comprador</th>
+                  <th>Tipo</th>
+                  <th>Cant.</th>
+                  <th>Total</th>
+                  <th>Pago</th>
+                  <th>Estado</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {orders.map((o) => (
+                  <tr key={o.id}>
+                    <td>
+                      {o.buyer_name}
+                      <br />
+                      <span className="muted" style={{ fontSize: 12 }}>
+                        {o.buyer_email}
+                      </span>
+                    </td>
+                    <td>{o.tier}</td>
+                    <td>{o.quantity}</td>
+                    <td>${(o.total_cents / 100).toFixed(2)}</td>
+                    <td>{o.payment_method}</td>
+                    <td>
+                      <span className={`badge badge--${o.status}`}>{o.status}</span>
+                    </td>
+                    <td>
+                      {o.status === 'pending' && (
+                        <button onClick={() => handleMarkPaid(o)} disabled={busyId === o.id}>
+                          {busyId === o.id ? '…' : 'Marcar pagada'}
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+                {orders.length === 0 && (
+                  <tr>
+                    <td colSpan={7} className="muted">
+                      No hay órdenes.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/ticket-system/src/admin/main.tsx
+++ b/ticket-system/src/admin/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import '../shared/styles.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/ticket-system/src/entradas/App.tsx
+++ b/ticket-system/src/entradas/App.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  createOrder,
+  getPresaleStatus,
+  type CreateOrderResponse,
+  type PresaleStatusResponse
+} from '../shared/api';
+import { EVENT, PAYMENT_METHODS, TIERS, type TierKey } from '../shared/config';
+import { Countdown } from './Countdown';
+
+type Method = (typeof PAYMENT_METHODS)[number]['value'];
+
+export default function App() {
+  const [presale, setPresale] = useState<PresaleStatusResponse | null>(null);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [tier, setTier] = useState<TierKey>('preventa');
+  const [quantity, setQuantity] = useState(1);
+  const [method, setMethod] = useState<Method>('cuantoapp');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [confirmation, setConfirmation] = useState<CreateOrderResponse | null>(null);
+
+  useEffect(() => {
+    getPresaleStatus().then(setPresale).catch(() => setPresale(null));
+  }, []);
+
+  const presaleSoldOut = presale?.soldOut ?? false;
+  const total = useMemo(() => TIERS[tier].priceCents * quantity, [tier, quantity]);
+
+  // If presale is sold out, default the buyer to general.
+  useEffect(() => {
+    if (presaleSoldOut && tier === 'preventa') setTier('general');
+  }, [presaleSoldOut, tier]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    setSubmitting(true);
+    try {
+      const result = await createOrder({
+        buyer_name: name,
+        buyer_email: email,
+        buyer_phone: phone || undefined,
+        tier,
+        quantity,
+        payment_method: method
+      });
+      setConfirmation(result);
+    } catch (err) {
+      const code = (err as Error & { code?: string }).code;
+      if (code === 'presale_sold_out') {
+        setError('La preventa se agotó. Refresca la página para comprar entrada general.');
+        getPresaleStatus().then(setPresale).catch(() => {});
+      } else if (code === 'invalid_email') {
+        setError('Revisa el correo: parece inválido.');
+      } else {
+        setError('No pudimos crear tu orden. Inténtalo de nuevo.');
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (confirmation) {
+    return <Confirmation data={confirmation} onReset={() => setConfirmation(null)} />;
+  }
+
+  return (
+    <div className="container">
+      <header style={{ marginBottom: 24 }}>
+        <p className="muted" style={{ margin: 0, textTransform: 'uppercase', letterSpacing: '0.1em' }}>
+          {EVENT.band}
+        </p>
+        <h1 style={{ margin: '4px 0' }}>{EVENT.name}</h1>
+        <p className="muted">
+          Una noche de covers de las bandas que nos inspiraron · {EVENT.venue} · 1 de agosto
+        </p>
+      </header>
+
+      <div className="card" style={{ marginBottom: 20 }}>
+        <Countdown />
+        <PresaleIndicator presale={presale} />
+      </div>
+
+      <form className="card" onSubmit={handleSubmit}>
+        <h2 style={{ marginTop: 0 }}>Compra tus entradas</h2>
+
+        <label htmlFor="tier">Tipo de entrada</label>
+        <select
+          id="tier"
+          value={tier}
+          onChange={(e) => setTier(e.target.value as TierKey)}
+        >
+          <option value="preventa" disabled={presaleSoldOut}>
+            {TIERS.preventa.label} — {TIERS.preventa.priceLabel}
+            {presaleSoldOut ? ' (agotada)' : ''}
+          </option>
+          <option value="general">
+            {TIERS.general.label} — {TIERS.general.priceLabel}
+          </option>
+        </select>
+
+        <label htmlFor="quantity">Cantidad</label>
+        <select
+          id="quantity"
+          value={quantity}
+          onChange={(e) => setQuantity(Number(e.target.value))}
+        >
+          {Array.from({ length: 10 }, (_, i) => i + 1).map((n) => (
+            <option key={n} value={n}>
+              {n}
+            </option>
+          ))}
+        </select>
+
+        <label htmlFor="name">Nombre completo</label>
+        <input id="name" value={name} onChange={(e) => setName(e.target.value)} required minLength={2} />
+
+        <label htmlFor="email">Correo electrónico</label>
+        <input
+          id="email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          autoComplete="email"
+        />
+        <p className="muted" style={{ marginTop: -10, fontSize: 13 }}>
+          Aquí enviaremos tu entrada con el código QR.
+        </p>
+
+        <label htmlFor="phone">Teléfono (opcional)</label>
+        <input id="phone" type="tel" value={phone} onChange={(e) => setPhone(e.target.value)} />
+
+        <label htmlFor="method">Método de pago</label>
+        <select id="method" value={method} onChange={(e) => setMethod(e.target.value as Method)}>
+          {PAYMENT_METHODS.map((m) => (
+            <option key={m.value} value={m.value}>
+              {m.label}
+            </option>
+          ))}
+        </select>
+
+        {error && <div className="alert alert--error">{error}</div>}
+
+        <button type="submit" disabled={submitting} style={{ width: '100%' }}>
+          {submitting ? 'Procesando…' : `Continuar — $${(total / 100).toFixed(2)}`}
+        </button>
+
+        <p className="muted" style={{ fontSize: 12, marginTop: 16 }}>
+          Compra directamente con la banda. Canales oficiales: @stilllouder. No vendemos por
+          intermediarios.
+        </p>
+      </form>
+    </div>
+  );
+}
+
+function PresaleIndicator({ presale }: { presale: PresaleStatusResponse | null }) {
+  if (!presale) return null;
+  if (presale.soldOut) {
+    return (
+      <p style={{ marginBottom: 0 }}>
+        <span className="badge badge--cancelled">Preventa agotada</span> — entrada general disponible
+        el día del evento.
+      </p>
+    );
+  }
+  return (
+    <p style={{ marginBottom: 0 }}>
+      <span className="badge badge--paid">Preventa abierta</span> Quedan{' '}
+      <strong>{presale.available}</strong> entradas de preventa.
+    </p>
+  );
+}
+
+function Confirmation({ data, onReset }: { data: CreateOrderResponse; onReset: () => void }) {
+  return (
+    <div className="container">
+      <div className="card">
+        <h1 style={{ marginTop: 0 }}>¡Orden creada! 🎟️</h1>
+        <p>
+          Reservamos {data.quantity} {data.quantity === 1 ? 'entrada' : 'entradas'} por un total de{' '}
+          <strong>{data.payment.amount}</strong>.
+        </p>
+
+        <div className="alert alert--success">
+          <strong>Siguiente paso — {data.payment.method === 'cash' ? 'Efectivo' : 'Pago'}:</strong>
+          <p style={{ margin: '8px 0 0' }}>{data.payment.note}</p>
+          {data.payment.link && (
+            <p style={{ marginBottom: 0 }}>
+              <a href={data.payment.link} target="_blank" rel="noopener noreferrer">
+                Ir a pagar →
+              </a>
+            </p>
+          )}
+        </div>
+
+        <p className="muted">
+          Tu entrada con el código QR llegará por correo en cuanto confirmemos el pago. Guarda tu
+          número de orden: <code>{data.orderId}</code>
+        </p>
+
+        <button className="secondary" onClick={onReset}>
+          Comprar otra entrada
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/ticket-system/src/entradas/Countdown.tsx
+++ b/ticket-system/src/entradas/Countdown.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from 'react';
+import { EVENT } from '../shared/config';
+
+function diffParts(target: number, now: number) {
+  const ms = Math.max(target - now, 0);
+  const days = Math.floor(ms / 86400000);
+  const hours = Math.floor((ms % 86400000) / 3600000);
+  const minutes = Math.floor((ms % 3600000) / 60000);
+  const seconds = Math.floor((ms % 60000) / 1000);
+  return { ms, days, hours, minutes, seconds };
+}
+
+export function Countdown() {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const presaleStart = new Date(EVENT.presaleStart).getTime();
+  const eventDate = new Date(EVENT.eventDate).getTime();
+
+  // Before presale opens we count down to that; afterwards, to the show.
+  const beforePresale = now < presaleStart;
+  const target = beforePresale ? presaleStart : eventDate;
+  const label = beforePresale ? 'La preventa abre en' : 'Faltan para el concierto';
+  const { days, hours, minutes, seconds } = diffParts(target, now);
+
+  return (
+    <div style={{ marginBottom: 16 }}>
+      <p className="muted" style={{ margin: '0 0 8px' }}>
+        {label}
+      </p>
+      <div style={{ display: 'flex', gap: 12 }}>
+        {[
+          { v: days, l: 'días' },
+          { v: hours, l: 'horas' },
+          { v: minutes, l: 'min' },
+          { v: seconds, l: 'seg' }
+        ].map((part) => (
+          <div key={part.l} className="stat" style={{ flex: 1 }}>
+            <div className="stat__value">{String(part.v).padStart(2, '0')}</div>
+            <div className="stat__label">{part.l}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/ticket-system/src/entradas/main.tsx
+++ b/ticket-system/src/entradas/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import '../shared/styles.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/ticket-system/src/shared/api.ts
+++ b/ticket-system/src/shared/api.ts
@@ -1,0 +1,173 @@
+// Thin fetch wrapper shared by all three surfaces. Passwords for the admin /
+// staff gates are passed per-call and sent as a Bearer header; they live only
+// in sessionStorage on the client and are checked server-side.
+
+export interface ApiError {
+  error: string;
+}
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const res = await fetch(path, {
+    ...init,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(init.headers ?? {})
+    }
+  });
+  const text = await res.text();
+  const data = text ? JSON.parse(text) : {};
+  if (!res.ok) {
+    const err = new Error((data as ApiError).error ?? `http_${res.status}`);
+    (err as Error & { status?: number }).status = res.status;
+    (err as Error & { code?: string }).code = (data as ApiError).error;
+    throw err;
+  }
+  return data as T;
+}
+
+function authHeader(password: string): Record<string, string> {
+  return { Authorization: `Bearer ${password}` };
+}
+
+// --- Public ------------------------------------------------------------------
+
+export interface PresaleStatusResponse {
+  available: number;
+  capacity: number;
+  stage2Active: boolean;
+  soldOut: boolean;
+}
+
+export function getPresaleStatus(): Promise<PresaleStatusResponse> {
+  return request<PresaleStatusResponse>('/api/presale/status');
+}
+
+export interface CreateOrderInput {
+  buyer_name: string;
+  buyer_email: string;
+  buyer_phone?: string;
+  tier: 'preventa' | 'general';
+  quantity: number;
+  payment_method: 'cuantoapp' | 'cash' | 'yappy';
+}
+
+export interface CreateOrderResponse {
+  orderId: string;
+  tier: string;
+  quantity: number;
+  totalCents: number;
+  reservationExpiresAt: string | null;
+  payment: { method: string; amount: string; link?: string; note: string };
+}
+
+export function createOrder(input: CreateOrderInput): Promise<CreateOrderResponse> {
+  return request<CreateOrderResponse>('/api/orders', {
+    method: 'POST',
+    body: JSON.stringify(input)
+  });
+}
+
+// --- Admin -------------------------------------------------------------------
+
+export interface AdminOrder {
+  id: string;
+  buyer_name: string;
+  buyer_email: string;
+  buyer_phone: string | null;
+  tier: string;
+  quantity: number;
+  total_cents: number;
+  payment_method: string;
+  payment_ref: string | null;
+  status: string;
+  created_at: string;
+  paid_at: string | null;
+  reservation_expires_at: string | null;
+  emailed_at: string | null;
+}
+
+export interface AdminStats {
+  presale: {
+    capacity: number;
+    paid: number;
+    pending: number;
+    available: number;
+    stage2Active: boolean;
+    soldOut: boolean;
+  };
+  generalPaid: number;
+  totalTicketsPaid: number;
+  revenueCents: number;
+}
+
+export interface AdminOrdersResponse {
+  orders: AdminOrder[];
+  stats: AdminStats;
+}
+
+export function fetchAdminOrders(
+  password: string,
+  params: { q?: string; status?: string } = {}
+): Promise<AdminOrdersResponse> {
+  const qs = new URLSearchParams();
+  if (params.q) qs.set('q', params.q);
+  if (params.status) qs.set('status', params.status);
+  const suffix = qs.toString() ? `?${qs}` : '';
+  return request<AdminOrdersResponse>(`/api/admin/orders${suffix}`, {
+    headers: authHeader(password)
+  });
+}
+
+export function markOrderPaid(
+  password: string,
+  orderId: string,
+  paymentRef?: string
+): Promise<{ orderId: string; status: string; ticketCount: number; emailed: boolean }> {
+  return request(`/api/admin/orders/${orderId}/mark-paid`, {
+    method: 'POST',
+    headers: authHeader(password),
+    body: JSON.stringify({ payment_ref: paymentRef ?? null })
+  });
+}
+
+export function toggleStage2(
+  password: string,
+  active: boolean
+): Promise<{ stage2Active: boolean }> {
+  return request('/api/admin/presale/stage2', {
+    method: 'POST',
+    headers: authHeader(password),
+    body: JSON.stringify({ active })
+  });
+}
+
+export function cleanupExpired(password: string): Promise<{ cancelled: number }> {
+  return request('/api/admin/orders/cleanup', {
+    method: 'POST',
+    headers: authHeader(password)
+  });
+}
+
+// --- Staff (gate) ------------------------------------------------------------
+
+export type ValidateOutcome = 'valid' | 'already_used' | 'void' | 'not_found' | 'forged';
+
+export interface ValidateResponse {
+  result: ValidateOutcome;
+  tier: string | null;
+  usedAt: string | null;
+  usedBy: string | null;
+  buyerName: string | null;
+}
+
+export function validateTicket(
+  password: string,
+  token: string,
+  station: string
+): Promise<ValidateResponse> {
+  return request<ValidateResponse>('/api/tickets/validate', {
+    method: 'POST',
+    headers: authHeader(password),
+    body: JSON.stringify({ token, station })
+  });
+}

--- a/ticket-system/src/shared/config.ts
+++ b/ticket-system/src/shared/config.ts
@@ -1,0 +1,25 @@
+// Client-side display config. NO secrets here — this is bundled into the
+// browser. Prices shown here are for display only; the server is authoritative.
+
+export const EVENT = {
+  name: 'When We Were Young 3',
+  shortName: 'WWWY3',
+  band: 'Still Louder',
+  venue: 'Hops',
+  // ISO dates (local Panama time, UTC-5).
+  presaleStart: '2026-06-15T00:00:00-05:00',
+  eventDate: '2026-08-01T20:00:00-05:00'
+} as const;
+
+export const TIERS = {
+  preventa: { label: 'Preventa', priceLabel: '$6', priceCents: 600 },
+  general: { label: 'General (día del evento)', priceLabel: '$8', priceCents: 800 }
+} as const;
+
+export type TierKey = keyof typeof TIERS;
+
+export const PAYMENT_METHODS = [
+  { value: 'cuantoapp', label: 'Tarjeta (CuantoApp)' },
+  { value: 'cash', label: 'Efectivo' }
+  // 'yappy' is enabled in Phase 2.
+] as const;

--- a/ticket-system/src/shared/styles.css
+++ b/ticket-system/src/shared/styles.css
@@ -1,0 +1,231 @@
+:root {
+  --bg: #0d0d0f;
+  --surface: #18181c;
+  --surface-2: #222228;
+  --border: #2e2e36;
+  --text: #f4f4f5;
+  --muted: #a1a1aa;
+  --accent: #e11d48;
+  --accent-hover: #be123c;
+  --green: #16a34a;
+  --red: #dc2626;
+  --amber: #d97706;
+  --radius: 12px;
+  --space: 16px;
+  font-family: system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  -webkit-font-smoothing: antialiased;
+  line-height: 1.5;
+}
+
+.container {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 24px var(--space);
+}
+
+h1,
+h2,
+h3 {
+  line-height: 1.2;
+}
+
+a {
+  color: var(--accent);
+}
+
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+}
+
+label {
+  display: block;
+  font-size: 14px;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+
+input,
+select {
+  width: 100%;
+  padding: 12px;
+  font-size: 16px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  margin-bottom: 16px;
+}
+
+input:focus,
+select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 0;
+}
+
+button {
+  font-size: 16px;
+  font-weight: 600;
+  padding: 12px 20px;
+  border: none;
+  border-radius: 8px;
+  background: var(--accent);
+  color: #fff;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+button:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button.secondary {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.badge--pending {
+  background: rgba(217, 119, 6, 0.2);
+  color: var(--amber);
+}
+
+.badge--paid {
+  background: rgba(22, 163, 74, 0.2);
+  color: var(--green);
+}
+
+.badge--cancelled {
+  background: rgba(220, 38, 38, 0.2);
+  color: var(--red);
+}
+
+.alert {
+  padding: 12px 16px;
+  border-radius: 8px;
+  margin: 16px 0;
+  font-size: 14px;
+}
+
+.alert--error {
+  background: rgba(220, 38, 38, 0.15);
+  border: 1px solid var(--red);
+}
+
+.alert--success {
+  background: rgba(22, 163, 74, 0.15);
+  border: 1px solid var(--green);
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+  margin: 16px 0;
+}
+
+.stat {
+  background: var(--surface-2);
+  border-radius: 8px;
+  padding: 12px;
+  text-align: center;
+}
+
+.stat__value {
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.stat__label {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 10px 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+th {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+/* --- Gate validator full-screen result --- */
+.gate-result {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  z-index: 10;
+  padding: 24px;
+}
+
+.gate-result--valid {
+  background: var(--green);
+}
+
+.gate-result--reject {
+  background: var(--red);
+}
+
+.gate-result__icon {
+  font-size: 96px;
+}
+
+.gate-result__title {
+  font-size: 40px;
+  font-weight: 800;
+  margin: 8px 0;
+}
+
+.gate-result__detail {
+  font-size: 20px;
+}
+
+#reader {
+  width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
+}

--- a/ticket-system/src/validar/App.tsx
+++ b/ticket-system/src/validar/App.tsx
@@ -1,0 +1,208 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Html5Qrcode } from 'html5-qrcode';
+import { validateTicket, type ValidateResponse } from '../shared/api';
+import { playAccept, playReject } from './sound';
+
+const PW_KEY = 'wwwy3_staff_pw';
+const STATION_KEY = 'wwwy3_station';
+
+export default function App() {
+  const [password, setPassword] = useState(() => sessionStorage.getItem(PW_KEY) ?? '');
+  const [station, setStation] = useState(() => sessionStorage.getItem(STATION_KEY) ?? 'puerta-1');
+  const [authed, setAuthed] = useState(false);
+
+  if (!authed) {
+    return (
+      <Gate
+        password={password}
+        setPassword={setPassword}
+        station={station}
+        setStation={setStation}
+        onSuccess={() => {
+          sessionStorage.setItem(PW_KEY, password);
+          sessionStorage.setItem(STATION_KEY, station);
+          setAuthed(true);
+        }}
+      />
+    );
+  }
+  return <Scanner password={password} station={station} />;
+}
+
+function Gate({
+  password,
+  setPassword,
+  station,
+  setStation,
+  onSuccess
+}: {
+  password: string;
+  setPassword: (v: string) => void;
+  station: string;
+  setStation: (v: string) => void;
+  onSuccess: () => void;
+}) {
+  const [error, setError] = useState('');
+  const [checking, setChecking] = useState(false);
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setChecking(true);
+    setError('');
+    // Probe with an obviously-forged token: a wrong password returns 401,
+    // a correct one returns 200 with result 'forged'. Either way no DB write.
+    try {
+      await validateTicket(password, 'PROBE', station);
+      onSuccess();
+    } catch (err) {
+      const status = (err as Error & { status?: number }).status;
+      if (status === 401) setError('Contraseña incorrecta.');
+      else setError('Error de conexión.');
+    } finally {
+      setChecking(false);
+    }
+  }
+
+  return (
+    <div className="container" style={{ maxWidth: 400 }}>
+      <form className="card" onSubmit={submit}>
+        <h1 style={{ marginTop: 0 }}>Validador de puerta</h1>
+        <label htmlFor="station">Estación</label>
+        <input id="station" value={station} onChange={(e) => setStation(e.target.value)} />
+        <label htmlFor="pw">Contraseña de staff</label>
+        <input
+          id="pw"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          autoFocus
+        />
+        {error && <div className="alert alert--error">{error}</div>}
+        <button type="submit" disabled={checking} style={{ width: '100%' }}>
+          {checking ? 'Verificando…' : 'Iniciar'}
+        </button>
+      </form>
+    </div>
+  );
+}
+
+type GateState =
+  | { kind: 'scanning' }
+  | { kind: 'checking' }
+  | { kind: 'result'; response: ValidateResponse };
+
+function Scanner({ password, station }: { password: string; station: string }) {
+  const [state, setState] = useState<GateState>({ kind: 'scanning' });
+  const scannerRef = useRef<Html5Qrcode | null>(null);
+  const lockRef = useRef(false); // prevents re-entrant scans while processing
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
+  const handleScan = useCallback(
+    async (decodedText: string) => {
+      if (lockRef.current) return;
+      lockRef.current = true;
+      const scanner = scannerRef.current;
+      try {
+        await scanner?.pause(true);
+      } catch {
+        /* ignore */
+      }
+      setState({ kind: 'checking' });
+      try {
+        const response = await validateTicket(password, decodedText, station);
+        if (response.result === 'valid') playAccept();
+        else playReject();
+        setState({ kind: 'result', response });
+      } catch {
+        playReject();
+        setState({
+          kind: 'result',
+          response: { result: 'forged', tier: null, usedAt: null, usedBy: null, buyerName: null }
+        });
+      }
+      // Auto-resume after showing the result.
+      window.setTimeout(() => {
+        setState({ kind: 'scanning' });
+        try {
+          scanner?.resume();
+        } catch {
+          /* ignore */
+        }
+        lockRef.current = false;
+      }, 2500);
+    },
+    [password, station]
+  );
+
+  useEffect(() => {
+    const scanner = new Html5Qrcode('reader', { verbose: false });
+    scannerRef.current = scanner;
+    scanner
+      .start(
+        { facingMode: 'environment' },
+        { fps: 10, qrbox: { width: 250, height: 250 } },
+        (decoded) => {
+          void handleScan(decoded);
+        },
+        () => {
+          /* per-frame decode errors are normal; ignore */
+        }
+      )
+      .catch(() => {
+        // Camera permission denied or unavailable.
+      });
+
+    return () => {
+      scanner
+        .stop()
+        .then(() => scanner.clear())
+        .catch(() => {});
+    };
+  }, [handleScan]);
+
+  return (
+    <div className="container">
+      <h1>Escanea la entrada — {station}</h1>
+      <div id="reader" />
+      {state.kind === 'checking' && <p className="muted">Verificando…</p>}
+      {state.kind === 'result' && <ResultOverlay response={state.response} />}
+      <p className="muted" style={{ fontSize: 13 }}>
+        Apunta la cámara al código QR. El resultado se muestra automáticamente.
+      </p>
+    </div>
+  );
+}
+
+function ResultOverlay({ response }: { response: ValidateResponse }) {
+  const isValid = response.result === 'valid';
+  const tierLabel = response.tier === 'preventa' ? 'Preventa' : response.tier === 'general' ? 'General' : '';
+
+  let title: string;
+  let detail = '';
+  if (isValid) {
+    title = '✓ VÁLIDA';
+    detail = [tierLabel, response.buyerName].filter(Boolean).join(' · ');
+  } else if (response.result === 'already_used') {
+    title = '✗ YA USADA';
+    const t = response.usedAt ? new Date(response.usedAt) : null;
+    detail = t
+      ? `Usada a las ${t.toLocaleTimeString('es-PA', { hour: '2-digit', minute: '2-digit' })}`
+      : 'Esta entrada ya fue validada';
+  } else if (response.result === 'not_found') {
+    title = '✗ NO EXISTE';
+  } else if (response.result === 'forged') {
+    title = '✗ FALSA';
+    detail = 'Firma inválida';
+  } else {
+    title = '✗ ANULADA';
+  }
+
+  return (
+    <div className={`gate-result ${isValid ? 'gate-result--valid' : 'gate-result--reject'}`}>
+      <div className="gate-result__icon">{isValid ? '🎟️' : '🚫'}</div>
+      <div className="gate-result__title">{title}</div>
+      {detail && <div className="gate-result__detail">{detail}</div>}
+    </div>
+  );
+}

--- a/ticket-system/src/validar/main.tsx
+++ b/ticket-system/src/validar/main.tsx
@@ -1,0 +1,10 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import '../shared/styles.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/ticket-system/src/validar/sound.ts
+++ b/ticket-system/src/validar/sound.ts
@@ -1,0 +1,33 @@
+// Tiny WebAudio beeper so staff get audible feedback without sound files.
+let ctx: AudioContext | null = null;
+
+function getCtx(): AudioContext | null {
+  if (typeof window === 'undefined') return null;
+  if (!ctx) {
+    const Ctor = window.AudioContext ?? (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+    if (!Ctor) return null;
+    ctx = new Ctor();
+  }
+  return ctx;
+}
+
+function beep(freq: number, durationMs: number) {
+  const audio = getCtx();
+  if (!audio) return;
+  const osc = audio.createOscillator();
+  const gain = audio.createGain();
+  osc.type = 'sine';
+  osc.frequency.value = freq;
+  gain.gain.value = 0.15;
+  osc.connect(gain).connect(audio.destination);
+  osc.start();
+  osc.stop(audio.currentTime + durationMs / 1000);
+}
+
+export function playAccept() {
+  beep(880, 150);
+}
+
+export function playReject() {
+  beep(220, 400);
+}

--- a/ticket-system/supabase/migrations/0001_init.sql
+++ b/ticket-system/supabase/migrations/0001_init.sql
@@ -1,0 +1,302 @@
+-- =============================================================================
+-- WWWY3 Ticket System — initial schema + atomic RPCs
+-- =============================================================================
+-- Run this against the Supabase project (SQL editor or `supabase db push`).
+-- All access is server-side via the service-role key, so Row Level Security is
+-- enabled with NO permissive policies: the service role bypasses RLS, and the
+-- anon/public key gets zero access. The frontend never talks to Supabase
+-- directly; it only calls our serverless functions.
+-- =============================================================================
+
+-- --- Tables ------------------------------------------------------------------
+
+create table if not exists orders (
+  id             uuid primary key default gen_random_uuid(),
+  buyer_name     text not null,
+  buyer_email    text not null,
+  buyer_phone    text,
+  tier           text not null check (tier in ('preventa','general')),
+  quantity       int  not null default 1 check (quantity > 0),
+  total_cents    int  not null,
+  payment_method text not null check (payment_method in ('yappy','cuantoapp','cash')),
+  payment_ref    text,
+  status         text not null default 'pending'
+                   check (status in ('pending','paid','cancelled')),
+  created_at     timestamptz not null default now(),
+  paid_at        timestamptz,
+  -- when the held presale cupo for a pending order is released
+  reservation_expires_at timestamptz,
+  -- set once the confirmation email (with QRs) has been sent; makes issuance
+  -- safely retryable / idempotent (re-marking paid never re-sends)
+  emailed_at     timestamptz
+);
+
+create table if not exists event_config (
+  id                      int primary key default 1 check (id = 1), -- single row
+  presale_stage1_cap      int not null default 75,
+  presale_stage2_cap      int not null default 75,
+  presale_stage2_active   boolean not null default false,
+  updated_at              timestamptz not null default now()
+);
+
+create table if not exists tickets (
+  id          uuid primary key default gen_random_uuid(),
+  order_id    uuid not null references orders(id) on delete cascade,
+  tier        text not null check (tier in ('preventa','general')),
+  status      text not null default 'valid' check (status in ('valid','used','void')),
+  used_at     timestamptz,
+  used_by     text,            -- identifier of the staff/station that validated
+  created_at  timestamptz not null default now()
+);
+
+-- Seed the single config row.
+insert into event_config (id) values (1) on conflict (id) do nothing;
+
+-- --- Indexes -----------------------------------------------------------------
+
+create index if not exists orders_status_idx        on orders (status);
+create index if not exists orders_tier_status_idx   on orders (tier, status);
+create index if not exists orders_email_idx          on orders (lower(buyer_email));
+create index if not exists orders_created_idx        on orders (created_at desc);
+create index if not exists tickets_order_idx         on tickets (order_id);
+create index if not exists tickets_status_idx        on tickets (status);
+
+-- --- Row Level Security (lock everything down) -------------------------------
+
+alter table orders       enable row level security;
+alter table event_config enable row level security;
+alter table tickets      enable row level security;
+-- No policies => only the service role (which bypasses RLS) can read/write.
+
+-- =============================================================================
+-- RPCs — all capacity / issuance logic that must be atomic lives here.
+-- =============================================================================
+
+-- --- Presale capacity snapshot ----------------------------------------------
+-- Returns the current presale numbers in a single consistent read.
+create or replace function presale_status()
+returns table (
+  capacity      int,
+  paid_count    int,
+  pending_count int,
+  committed     int,
+  available     int,
+  stage2_active boolean,
+  sold_out      boolean
+)
+language plpgsql
+stable
+as $$
+declare
+  v_cfg event_config;
+begin
+  select * into v_cfg from event_config where id = 1;
+
+  capacity := v_cfg.presale_stage1_cap +
+    case when v_cfg.presale_stage2_active then v_cfg.presale_stage2_cap else 0 end;
+
+  select coalesce(sum(quantity), 0) into paid_count
+  from orders where tier = 'preventa' and status = 'paid';
+
+  select coalesce(sum(quantity), 0) into pending_count
+  from orders
+  where tier = 'preventa'
+    and status = 'pending'
+    and reservation_expires_at > now();
+
+  committed     := paid_count + pending_count;
+  available     := greatest(capacity - committed, 0);
+  stage2_active := v_cfg.presale_stage2_active;
+  sold_out      := committed >= capacity;
+  return next;
+end;
+$$;
+
+-- --- Atomic order creation with race-safe presale capacity check ------------
+-- For 'preventa' we take a row lock on the single event_config row, which
+-- serializes every concurrent presale purchase. This makes the
+-- "count then insert" sequence atomic: two near-simultaneous orders cannot
+-- both slip past the cap. 'general' tier skips the lock (capped by venue, not
+-- here). Raises a custom exception when the cupo would be exceeded.
+create or replace function create_order(
+  p_buyer_name         text,
+  p_buyer_email        text,
+  p_buyer_phone        text,
+  p_tier               text,
+  p_quantity           int,
+  p_total_cents        int,
+  p_payment_method     text,
+  p_reservation_minutes int
+)
+returns orders
+language plpgsql
+as $$
+declare
+  v_cfg       event_config;
+  v_capacity  int;
+  v_committed int;
+  v_order     orders;
+begin
+  if p_tier = 'preventa' then
+    -- Serialize presale capacity decisions on the single config row.
+    select * into v_cfg from event_config where id = 1 for update;
+
+    v_capacity := v_cfg.presale_stage1_cap +
+      case when v_cfg.presale_stage2_active then v_cfg.presale_stage2_cap else 0 end;
+
+    select coalesce(sum(quantity), 0) into v_committed
+    from orders
+    where tier = 'preventa'
+      and (status = 'paid'
+           or (status = 'pending' and reservation_expires_at > now()));
+
+    if v_committed + p_quantity > v_capacity then
+      raise exception 'PRESALE_SOLD_OUT'
+        using errcode = 'P0001',
+              detail  = format('available=%s requested=%s',
+                               greatest(v_capacity - v_committed, 0), p_quantity);
+    end if;
+  end if;
+
+  insert into orders (
+    buyer_name, buyer_email, buyer_phone, tier, quantity,
+    total_cents, payment_method, status, reservation_expires_at
+  )
+  values (
+    p_buyer_name, p_buyer_email, p_buyer_phone, p_tier, p_quantity,
+    p_total_cents, p_payment_method, 'pending',
+    now() + make_interval(mins => p_reservation_minutes)
+  )
+  returning * into v_order;
+
+  return v_order;
+end;
+$$;
+
+-- --- Mark an order paid + issue tickets (idempotent) ------------------------
+-- Transitions pending -> paid and creates one ticket per admission. Safe to
+-- call repeatedly: the status transition only fires once, and tickets are only
+-- created when none exist for the order. Returns the order plus a flag telling
+-- the caller whether THIS call was the transition that flipped it to paid
+-- (so the caller knows whether fresh work happened — emailing is gated
+-- separately on orders.emailed_at).
+create or replace function mark_order_paid(
+  p_order_id    uuid,
+  p_payment_ref text
+)
+returns orders
+language plpgsql
+as $$
+declare
+  v_order    orders;
+  v_existing int;
+begin
+  update orders
+    set status      = 'paid',
+        paid_at     = coalesce(paid_at, now()),
+        payment_ref = coalesce(p_payment_ref, payment_ref)
+    where id = p_order_id and status = 'pending'
+    returning * into v_order;
+
+  if not found then
+    select * into v_order from orders where id = p_order_id;
+    if v_order.id is null then
+      raise exception 'ORDER_NOT_FOUND' using errcode = 'P0002';
+    end if;
+    if v_order.status = 'cancelled' then
+      raise exception 'ORDER_CANCELLED' using errcode = 'P0003';
+    end if;
+    -- else: already 'paid' — fall through, tickets guard below is idempotent
+  end if;
+
+  select count(*) into v_existing from tickets where order_id = p_order_id;
+  if v_existing = 0 then
+    insert into tickets (order_id, tier, status)
+    select v_order.id, v_order.tier, 'valid'
+    from generate_series(1, v_order.quantity);
+  end if;
+
+  return v_order;
+end;
+$$;
+
+-- --- Mark the confirmation email as sent ------------------------------------
+create or replace function mark_order_emailed(p_order_id uuid)
+returns void
+language sql
+as $$
+  update orders set emailed_at = coalesce(emailed_at, now()) where id = p_order_id;
+$$;
+
+-- --- Atomic ticket validation (anti double-use) -----------------------------
+-- Wins the race between simultaneous scans: only the first UPDATE flips
+-- valid -> used. Returns a single classified row describing the outcome so the
+-- gate UI can render green/red without a second round-trip.
+create or replace function validate_ticket(
+  p_ticket_id uuid,
+  p_used_by   text
+)
+returns table (
+  result   text,        -- 'valid' | 'already_used' | 'void' | 'not_found'
+  ticket_id uuid,
+  tier     text,
+  used_at  timestamptz,
+  used_by  text,
+  buyer_name text
+)
+language plpgsql
+as $$
+declare
+  v_ticket tickets;
+begin
+  update tickets
+    set status  = 'used',
+        used_at = now(),
+        used_by = p_used_by
+    where id = p_ticket_id and status = 'valid'
+    returning * into v_ticket;
+
+  if found then
+    result := 'valid';
+  else
+    select * into v_ticket from tickets where id = p_ticket_id;
+    if v_ticket.id is null then
+      result := 'not_found';
+      return next;
+      return;
+    elsif v_ticket.status = 'used' then
+      result := 'already_used';
+    else
+      result := 'void';
+    end if;
+  end if;
+
+  ticket_id := v_ticket.id;
+  tier      := v_ticket.tier;
+  used_at   := v_ticket.used_at;
+  used_by   := v_ticket.used_by;
+  select o.buyer_name into buyer_name from orders o where o.id = v_ticket.order_id;
+  return next;
+end;
+$$;
+
+-- --- Release cupo from expired pending orders -------------------------------
+create or replace function cleanup_expired_orders()
+returns int
+language plpgsql
+as $$
+declare
+  v_count int;
+begin
+  with cancelled as (
+    update orders
+      set status = 'cancelled'
+      where status = 'pending'
+        and reservation_expires_at is not null
+        and reservation_expires_at < now()
+      returning 1
+  )
+  select count(*) into v_count from cancelled;
+  return v_count;
+end;
+$$;

--- a/ticket-system/tsconfig.api.json
+++ b/ticket-system/tsconfig.api.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["api"]
+}

--- a/ticket-system/tsconfig.json
+++ b/ticket-system/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/ticket-system/tsconfig.node.json
+++ b/ticket-system/tsconfig.node.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["vite.config.ts"]
+}

--- a/ticket-system/validar.html
+++ b/ticket-system/validar.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Validar — Still Louder</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/validar/main.tsx"></script>
+  </body>
+</html>

--- a/ticket-system/vercel.json
+++ b/ticket-system/vercel.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "vite",
+  "buildCommand": "vite build",
+  "outputDirectory": "dist",
+  "cleanUrls": true,
+  "trailingSlash": false,
+  "crons": [
+    { "path": "/api/admin/orders/cleanup", "schedule": "0 * * * *" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' https://*.supabase.co; font-src 'self'; media-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
+        },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(self), microphone=(), geolocation=(), payment=(), usb=(), interest-cohort=()"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=63072000; includeSubDomains; preload"
+        }
+      ]
+    },
+    {
+      "source": "/api/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store" }
+      ]
+    }
+  ]
+}

--- a/ticket-system/vite.config.ts
+++ b/ticket-system/vite.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'node:path';
+
+// Multi-page app: three independent surfaces share one build.
+//   /entradas  -> public buyer flow
+//   /admin     -> staff back office (mark paid, stats, stage 2)
+//   /validar   -> gate scanner (PWA-ish)
+// The root index.html just redirects to /entradas.
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'index.html'),
+        entradas: resolve(__dirname, 'entradas.html'),
+        admin: resolve(__dirname, 'admin.html'),
+        validar: resolve(__dirname, 'validar.html')
+      }
+    }
+  },
+  server: {
+    port: 3100
+  }
+});


### PR DESCRIPTION
Sistema de entradas autónomo para When We Were Young 3:
- Schema Supabase + RPCs atómicas (cupo race-safe, emisión idempotente,
  validación anti doble-uso)
- API serverless (orders, presale status, mark-paid, stage2, cleanup,
  ticket validate, QR image, Yappy webhook stub)
- Emisión agnóstica al método de pago (QR firmado HMAC + correo Resend)
- Frontend React/TS: compra (/entradas), panel admin (/admin),
  validador de puerta (/validar)
- Cupo de preventa por etapas (75 + 75) con toggle de Etapa 2
- Despliegue como proyecto Vercel aparte (subdominio)