### PR TITLE
Adjust cron frequency to daily and clarify capacity logic

### DIFF
--- a/ticket-system/README.md
+++ b/ticket-system/README.md
@@ -115,8 +115,18 @@ Crea un **segundo proyecto Vercel** apuntando al mismo repo con:
 
 El sitio estático actual (raíz del repo) sigue siendo su propio proyecto Vercel,
 intacto. `vercel.json` aquí define headers de seguridad (CSP, HSTS,
-`Permissions-Policy: camera=(self)` para el escáner) y el **cron horario** que
+`Permissions-Policy: camera=(self)` para el escáner) y el **cron diario** que
 ejecuta `/api/admin/orders/cleanup`.
+
+> **Frecuencia del cron de limpieza:** el plan **Hobby** (gratis) de Vercel solo
+> permite crons **una vez al día**; una expresión horaria falla el deploy con
+> _"Hobby accounts are limited to daily cron jobs"_. Por eso el `schedule` en
+> `vercel.json` es `"0 6 * * *"` (diario; en Hobby, Vercel lo dispara en algún
+> momento dentro de esa hora). Esto **no afecta la disponibilidad de cupos**: el
+> conteo libera las reservas vencidas por timestamp (`reservation_expires_at >
+> now()`), así que la limpieza es solo housekeeping (marcar como `cancelled`). Si
+> suben a **Vercel Pro**, pueden volver a una frecuencia horaria (`"0 * * * *"`).
+> El JSON no admite comentarios, por eso esta nota vive aquí y no en `vercel.json`.
 
 > Alternativa: integrarlo en el proyecto existente bajo `/entradas` y `/validar`.
 > Se eligió el proyecto aparte por la configuración inusual de `publicDir` del
@@ -153,9 +163,11 @@ El secreto vive solo en el servidor; es imposible fabricar entradas válidas sin
   vigentes.
 - **Etapa 2 inmediata:** la capacidad se recalcula en vivo desde `event_config`;
   el toggle abre 75 cupos al instante.
-- **Pending vencida libera cupo:** `cleanup_expired_orders` (cron horario + botón
-  admin) cancela pendientes vencidas; el conteo de cupo solo cuenta pendientes
-  con `reservation_expires_at > now()`.
+- **Pending vencida libera cupo:** el conteo de cupo (`presale_status` y
+  `create_order`) solo cuenta pendientes con `reservation_expires_at > now()`,
+  así que una reserva vencida libera su cupo **al instante por timestamp**, sin
+  esperar a la limpieza. `cleanup_expired_orders` (cron diario + botón admin) es
+  solo housekeeping: marca esas pendientes como `cancelled`.
 - **Correo desde `entradas@stilllouder.space`:** configurable vía `EMAIL_FROM`
   (requiere dominio verificado en Resend — DKIM/SPF/DMARC).
 

--- a/ticket-system/api/admin/orders/cleanup.ts
+++ b/ticket-system/api/admin/orders/cleanup.ts
@@ -4,8 +4,11 @@ import { isAdmin, isCron } from '../../_lib/auth.js';
 import { methodNotAllowed, sendJson, withErrorHandling } from '../../_lib/http.js';
 
 // POST /api/admin/orders/cleanup -> cancels expired pending orders, freeing
-// their reserved presale cupo. Runs on an hourly Vercel Cron (authenticated via
-// CRON_SECRET) and is also callable manually from the admin panel.
+// their reserved presale cupo. Runs on a daily Vercel Cron (authenticated via
+// CRON_SECRET) and is also callable manually from the admin panel. This is just
+// housekeeping: capacity already excludes expired pending orders by timestamp
+// (reservation_expires_at > now()), so a reserva frees its cupo the instant it
+// expires, regardless of when this cleanup runs.
 export default withErrorHandling(async (req: VercelRequest, res: VercelResponse) => {
   // Cron uses GET; the admin button uses POST.
   if (req.method !== 'POST' && req.method !== 'GET') {

--- a/ticket-system/vercel.json
+++ b/ticket-system/vercel.json
@@ -6,7 +6,7 @@
   "cleanUrls": true,
   "trailingSlash": false,
   "crons": [
-    { "path": "/api/admin/orders/cleanup", "schedule": "0 * * * *" }
+    { "path": "/api/admin/orders/cleanup", "schedule": "0 6 * * *" }
   ],
   "headers": [
     {


### PR DESCRIPTION
## Summary

Updates the presale cleanup cron job from hourly to daily frequency to comply with Vercel's Hobby plan limitations, and clarifies that capacity is managed by timestamp rather than the cleanup job.

## Changes

- **Cron schedule**: Changed from `"0 * * * *"` (hourly) to `"0 6 * * *"` (daily at 6 AM UTC) in `vercel.json`
- **Documentation**: Added comprehensive explanation in README about Vercel Hobby plan cron limitations and the distinction between capacity management (timestamp-based) and cleanup (housekeeping)
- **Code comments**: Updated `cleanup.ts` to clarify that the cleanup endpoint is housekeeping only—expired reservations free their quota instantly via timestamp checks (`reservation_expires_at > now()`), not by waiting for the cron job

## Implementation Details

The key insight is that capacity calculations in `presale_status` and `create_order` already exclude expired pending orders by checking `reservation_expires_at > now()`, so quotas are freed immediately when a reservation expires. The `cleanup_expired_orders` cron job only marks those expired orders as `cancelled` for database hygiene. This allows the cron to run less frequently without affecting user-facing availability.

The README now includes a note explaining that Vercel Hobby accounts are limited to daily cron jobs, and users can upgrade to Vercel Pro to restore hourly frequency if needed.

https://claude.ai/code/session_01XaUXFTQo2xniJvsiJ8i2wr