### PR TITLE
Update streaming platform links to new track

### DIFF
--- a/public/assets/js/config.js
+++ b/public/assets/js/config.js
@@ -8,13 +8,13 @@ export const CONFIG = {
   platforms: {
     spotify: {
       name: 'Spotify',
-      url: 'https://open.spotify.com/track/4zBlVazxK6AQBMPZl9Rcgj?si=a96b91e05196497f',
+      url: 'https://open.spotify.com/track/7jc86BEyQt8sdJsEbqtllU?si=1c59b85003e84b02',
       icon: 'spotify',
       color: '#1db954'
     },
     appleMusic: {
       name: 'Apple Music',
-      url: 'https://music.apple.com/pa/album/al-vac%C3%ADo/1829334537?i=1829334538',
+      url: 'https://music.apple.com/pa/album/skirlaz/1871380684?i=1871380685&l=en-GB',
       icon: 'apple-music',
       color: '#fa243c'
     },
@@ -26,13 +26,13 @@ export const CONFIG = {
     },
     deezer: {
       name: 'Deezer',
-      url: 'https://link.deezer.com/s/30BAvwIohgJLbpIWKmFld',
+      url: 'https://link.deezer.com/s/33uBZiHm7eOvA8b5tzklb',
       icon: 'deezer',
       color: '#ff0092'
     },
     amazonMusic: {
       name: 'Amazon Music',
-      url: 'https://music.amazon.com/tracks/B0FK3D2CK6',
+      url: 'https://music.amazon.com/tracks/B0GJ7DHTMV?marketplaceId=ATVPDKIKX0DER&musicTerritory=US&ref=dm_sh_fJNxSrdaEGv6WxGuYZQFb117Y',
       icon: 'amazon-music',
       color: '#232f3e'
     }

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -361,8 +361,8 @@ const initPWAShortcuts = () => {
     });
 
     const platformMap = {
-      spotify: 'https://open.spotify.com/track/4zBlVazxK6AQBMPZl9Rcgj?si=a96b91e05196497f',
-      apple: 'https://music.apple.com/pa/album/al-vac%C3%ADo/1829334537?i=1829334538',
+      spotify: 'https://open.spotify.com/track/7jc86BEyQt8sdJsEbqtllU?si=1c59b85003e84b02',
+      apple: 'https://music.apple.com/pa/album/skirlaz/1871380684?i=1871380685&l=en-GB',
       youtube: 'https://youtu.be/ukpbbWdqh_A'
     };
 

--- a/public/index.html
+++ b/public/index.html
@@ -178,7 +178,7 @@
               "price": "0",
               "priceCurrency": "USD",
               "availability": "https://schema.org/InStock",
-              "url": "https://open.spotify.com/track/4zBlVazxK6AQBMPZl9Rcgj",
+              "url": "https://open.spotify.com/track/7jc86BEyQt8sdJsEbqtllU",
               "seller": {
                 "@type": "Organization",
                 "name": "Spotify"
@@ -189,7 +189,7 @@
               "price": "0",
               "priceCurrency": "USD",
               "availability": "https://schema.org/InStock",
-              "url": "https://music.apple.com/pa/album/al-vac%C3%ADo/1829334537?i=1829334538",
+              "url": "https://music.apple.com/pa/album/skirlaz/1871380684?i=1871380685",
               "seller": {
                 "@type": "Organization",
                 "name": "Apple Music"
@@ -448,7 +448,7 @@
             role="navigation"
           >
             <a
-              href="https://open.spotify.com/track/4zBlVazxK6AQBMPZl9Rcgj?si=a96b91e05196497f"
+              href="https://open.spotify.com/track/7jc86BEyQt8sdJsEbqtllU?si=1c59b85003e84b02"
               class="platform-card glass-card reveal-up"
               id="spotify-link"
               target="_blank"
@@ -475,7 +475,7 @@
             </a>
 
             <a
-              href="https://music.apple.com/pa/album/al-vac%C3%ADo/1829334537?i=1829334538"
+              href="https://music.apple.com/pa/album/skirlaz/1871380684?i=1871380685&amp;l=en-GB"
               class="platform-card glass-card reveal-up"
               id="apple-link"
               target="_blank"
@@ -530,7 +530,7 @@
             </a>
 
             <a
-              href="https://link.deezer.com/s/30BAvwIohgJLbpIWKmFld"
+              href="https://link.deezer.com/s/33uBZiHm7eOvA8b5tzklb"
               class="platform-card glass-card reveal-up"
               id="deezer-link"
               target="_blank"
@@ -557,7 +557,7 @@
             </a>
 
             <a
-              href="https://music.amazon.com/tracks/B0FK3D2CK6"
+              href="https://music.amazon.com/tracks/B0GJ7DHTMV?marketplaceId=ATVPDKIKX0DER&amp;musicTerritory=US&amp;ref=dm_sh_fJNxSrdaEGv6WxGuYZQFb117Y"
               class="platform-card glass-card reveal-up"
               id="amazon-link"
               target="_blank"


### PR DESCRIPTION
## Summary
Updates all streaming platform links across the website to point to a new track, replacing the previous "Al Vacío" links with new track URLs.

## Changes Made
- **Spotify**: Updated track ID from `4zBlVazxK6AQBMPZl9Rcgj` to `7jc86BEyQt8sdJsEbqtllU` with new share parameter
- **Apple Music**: Changed from "al-vacío" album to "skirlaz" album with updated IDs and added locale parameter (`l=en-GB`)
- **Deezer**: Updated share link from `30BAvwIohgJLbpIWKmFld` to `33uBZiHm7eOvA8b5tzklb`
- **Amazon Music**: Updated track ID from `B0FK3D2CK6` to `B0GJ7DHTMV` with additional parameters for marketplace and territory

## Files Modified
- `public/index.html`: Updated all platform links in both schema.org structured data and the listening section
- `public/assets/js/config.js`: Updated centralized platform configuration
- `public/assets/js/main.js`: Updated PWA shortcuts platform map

All changes maintain consistency across the codebase by updating the centralized configuration in `config.js` and corresponding references in HTML and main.js.

https://claude.ai/code/session_01NPvP6tF8w4TMxaNEJQASoG