### PR TITLE
Expand social grid layout from 3 to 4 columns

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -829,9 +829,9 @@ body {
 
 .social-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: var(--spacing-md);
-  max-width: 600px;
+  max-width: 800px;
   margin: 0 auto var(--spacing-3xl);
 }
 


### PR DESCRIPTION
## Summary
Updated the social media grid layout to display 4 columns instead of 3, with a corresponding increase in max-width to accommodate the wider layout.

## Changes
- **Grid columns**: Changed from `repeat(3, 1fr)` to `repeat(4, 1fr)` to display 4 items per row
- **Max width**: Increased from `600px` to `800px` to provide adequate space for the 4-column layout

## Details
This change improves the visual presentation of the social media links section by utilizing horizontal space more effectively. The increased max-width ensures proper spacing and prevents the grid items from appearing cramped on wider viewports.

https://claude.ai/code/session_01CUP9JfNeiojGX53rKkrDWK