### PR TITLE
feat: notify operator by email when a purchase is registered

### DIFF
--- a/ticket-system/.env.example
+++ b/ticket-system/.env.example
@@ -14,6 +14,9 @@ SUPABASE_SERVICE_ROLE_KEY=
 RESEND_API_KEY=
 # From address — domain must be verified in Resend (DKIM/SPF/DMARC).
 EMAIL_FROM="Still Louder <entradas@stilllouder.space>"
+# Internal recipient(s) notified when a purchase is registered (order created).
+# Optional: leave empty to disable. Accepts a comma-separated list of addresses.
+ORDER_NOTIFICATION_EMAIL=
 
 # --- QR signing --------------------------------------------------------------
 # Long random secret. Generate with: openssl rand -hex 32

--- a/ticket-system/README.md
+++ b/ticket-system/README.md
@@ -81,6 +81,7 @@ Todas son **server-only**; ninguna se expone al navegador.
 ```
 SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
 RESEND_API_KEY, EMAIL_FROM="Still Louder <entradas@stilllouder.space>"
+ORDER_NOTIFICATION_EMAIL      # opcional: aviso interno al registrarse una compra (lista separada por comas)
 TICKET_HMAC_SECRET            # openssl rand -hex 32
 ADMIN_PASSWORD, STAFF_PASSWORD
 CRON_SECRET                   # para el cron de limpieza (openssl rand -hex 16)

--- a/ticket-system/api/_lib/email.ts
+++ b/ticket-system/api/_lib/email.ts
@@ -14,6 +14,28 @@ const TIER_LABEL: Record<string, string> = {
   general: 'General'
 };
 
+const METHOD_LABEL: Record<string, string> = {
+  yappy: 'Yappy',
+  cuantoapp: 'Tarjeta (CuantoApp)',
+  cash: 'Efectivo'
+};
+
+function formatMoney(totalCents: number): string {
+  return `$${(totalCents / 100).toFixed(2)}`;
+}
+
+function formatPanamaDate(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat('es-PA', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+      timeZone: 'America/Panama'
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
 function escapeHtml(value: string): string {
   return value
     .replace(/&/g, '&amp;')
@@ -174,5 +196,108 @@ export async function sendTicketEmail(order: Order, tokens: string[]): Promise<v
     subject: 'Tu entrada para WWWY3 — Still Louder',
     html,
     attachments
+  });
+}
+
+/**
+ * Aviso interno al operador cuando se REGISTRA una compra (orden creada, aún
+ * pendiente de pago). Best-effort: el endpoint de compra nunca debe fallar por
+ * esto. Solo se envía si ORDER_NOTIFICATION_EMAIL está configurada.
+ */
+export async function sendOrderNotificationEmail(order: Order): Promise<void> {
+  const recipients = env.orderNotificationEmail
+    .split(',')
+    .map((addr) => addr.trim())
+    .filter(Boolean);
+  if (recipients.length === 0) return;
+
+  const tierLabel = TIER_LABEL[order.tier] ?? order.tier;
+  const methodLabel = METHOD_LABEL[order.payment_method] ?? order.payment_method;
+  const adminUrl = `${env.publicBaseUrl}/admin`;
+
+  const serifFont = "Georgia,'Times New Roman',Times,serif";
+  const patchFont = "'Arial Black',Arial,Helvetica,sans-serif";
+
+  const detailRow = (label: string, value: string) => `
+    <tr>
+      <td style="padding:7px 0;font-family:${patchFont};font-size:11px;letter-spacing:2px;text-transform:uppercase;color:#8a6db0;width:110px;vertical-align:top;white-space:nowrap;">${label}</td>
+      <td style="padding:7px 0;font-size:15px;color:#15121c;font-weight:bold;">${value}</td>
+    </tr>`;
+
+  const phoneRow = order.buyer_phone ? detailRow('Teléfono', escapeHtml(order.buyer_phone)) : '';
+
+  const html = `
+    <div style="background:#2c1c4a;padding:24px 12px;font-family:Arial,Helvetica,sans-serif;">
+      <table role="presentation" width="560" cellpadding="0" cellspacing="0" align="center"
+             style="max-width:560px;margin:0 auto;background:#f6f5f8;border-radius:14px;overflow:hidden;color:#15121c;">
+        <tr>
+          <td style="background:#3e2768;padding:28px 24px 24px;text-align:center;">
+            <div style="font-family:${patchFont};font-size:12px;color:#ff6cb6;letter-spacing:3px;text-transform:uppercase;margin-bottom:10px;">
+              Still Louder · WWWY3
+            </div>
+            <div style="font-family:${serifFont};font-size:27px;color:#ffffff;line-height:1.15;">
+              Nueva compra registrada 🎟️
+            </div>
+          </td>
+        </tr>
+        <tr><td style="height:5px;background:#ff2e93;font-size:0;line-height:0;">&nbsp;</td></tr>
+        <tr>
+          <td style="padding:26px 24px 8px;">
+            <p style="margin:0 0 20px;font-size:16px;line-height:1.6;">
+              Se registró una orden <strong>pendiente de pago</strong>. Revisa los detalles y
+              márcala como pagada en el panel cuando confirmes el pago.
+            </p>
+
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0"
+                   style="background:#ffffff;border:1px solid #e1dfe9;border-left:5px solid #ff2e93;border-radius:10px;">
+              <tr>
+                <td style="padding:18px 20px;">
+                  <div style="font-family:${serifFont};font-style:italic;font-size:19px;color:#3e2768;margin-bottom:10px;">
+                    Detalles de la orden
+                  </div>
+                  <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
+                    ${detailRow('Comprador', escapeHtml(order.buyer_name))}
+                    ${detailRow('Correo', escapeHtml(order.buyer_email))}
+                    ${phoneRow}
+                    ${detailRow('Tipo', escapeHtml(tierLabel))}
+                    ${detailRow('Cantidad', `${order.quantity} ${order.quantity === 1 ? 'entrada' : 'entradas'}`)}
+                    ${detailRow('Total', formatMoney(order.total_cents))}
+                    ${detailRow('Pago', escapeHtml(methodLabel))}
+                    ${detailRow('Fecha', escapeHtml(formatPanamaDate(order.created_at)))}
+                    ${detailRow('Orden', `#${order.id}`)}
+                  </table>
+                </td>
+              </tr>
+            </table>
+
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:22px;">
+              <tr>
+                <td align="center">
+                  <a href="${adminUrl}"
+                     style="display:inline-block;background:#ff2e93;color:#ffffff;text-decoration:none;
+                            font-family:${patchFont};font-size:14px;letter-spacing:2px;text-transform:uppercase;
+                            padding:14px 28px;border-radius:8px;">
+                    Abrir panel de administración
+                  </a>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td style="background:#3e2768;padding:18px 24px;text-align:center;">
+            <div style="font-family:${patchFont};font-size:10px;letter-spacing:2px;color:#9b86c4;text-transform:uppercase;">
+              Aviso automático · Sistema de entradas
+            </div>
+          </td>
+        </tr>
+      </table>
+    </div>`;
+
+  await getResend().emails.send({
+    from: env.emailFrom,
+    to: recipients,
+    subject: `Nueva compra: ${order.buyer_name} · ${order.quantity}x ${tierLabel} · ${formatMoney(order.total_cents)}`,
+    html
   });
 }

--- a/ticket-system/api/_lib/env.ts
+++ b/ticket-system/api/_lib/env.ts
@@ -28,6 +28,12 @@ export const env = {
   get emailFrom() {
     return optional('EMAIL_FROM', 'Still Louder <entradas@stilllouder.space>');
   },
+  // Destinatario(s) interno(s) que reciben aviso cuando se registra una compra.
+  // Opcional: si no se configura, no se envía el aviso (feature opt-in).
+  // Acepta varias direcciones separadas por coma.
+  get orderNotificationEmail() {
+    return optional('ORDER_NOTIFICATION_EMAIL');
+  },
   get ticketHmacSecret() {
     return required('TICKET_HMAC_SECRET');
   },

--- a/ticket-system/api/orders.ts
+++ b/ticket-system/api/orders.ts
@@ -2,6 +2,7 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getSupabase } from './_lib/supabase.js';
 import { methodNotAllowed, parseBody, sendJson, withErrorHandling } from './_lib/http.js';
 import { MAX_QUANTITY_PER_ORDER, priceFor, reservationMinutesFor } from './_lib/pricing.js';
+import { sendOrderNotificationEmail } from './_lib/email.js';
 import type { Order, PaymentMethod, Tier } from './_lib/types.js';
 
 const TIERS: Tier[] = ['preventa', 'general'];
@@ -93,6 +94,14 @@ export default withErrorHandling(async (req: VercelRequest, res: VercelResponse)
       return sendJson(res, 409, { error: 'presale_sold_out' });
     }
     throw new Error(`create_order failed: ${error.message}`);
+  }
+
+  // Aviso interno al operador de que se registró una compra. Best-effort: un
+  // fallo de correo no debe tumbar la creación de la orden ni afectar al comprador.
+  try {
+    await sendOrderNotificationEmail(order!);
+  } catch (notifyError) {
+    console.error('[orders] order notification email failed', notifyError);
   }
 
   return sendJson(res, 201, {


### PR DESCRIPTION
Sends a simple, informative internal email each time an order is created
(POST /api/orders), with buyer/order details and a link to the admin panel.
Recipient is configurable via the optional ORDER_NOTIFICATION_EMAIL env var
(comma-separated list); when unset the notification is skipped. The send is
best-effort and wrapped in try/catch so it never blocks order creation.

https://claude.ai/code/session_01SoZTg6aZv1TVpUhfj2izcC