### PR TITLE
Style ticket system title and byline with color hierarchy

### DIFF
--- a/ticket-system/src/entradas/App.tsx
+++ b/ticket-system/src/entradas/App.tsx
@@ -82,7 +82,9 @@ export default function App() {
                 WERE YOUNG <span className="num">3</span>
               </span>
             </h1>
-            <div className="tk-byline">by {EVENT.band}</div>
+            <div className="tk-byline">
+              by <span className="band">{EVENT.band}</span>
+            </div>
           </div>
         </div>
 

--- a/ticket-system/src/entradas/theme.css
+++ b/ticket-system/src/entradas/theme.css
@@ -196,17 +196,19 @@ body::before {
 .tk-title .l1 {
   font-size: clamp(30px, 9vw, 48px);
   display: block;
+  color: var(--pink);
   letter-spacing: 1px;
 }
 .tk-title .l2 {
   font-size: clamp(46px, 16vw, 92px);
   display: block;
-  color: var(--pink);
+  color: var(--ink);
   letter-spacing: 0.5px;
 }
 .tk-title .num {
   /* mismo marcador que el resto del titular (Permanent Marker incluye dígitos);
      solo separamos un poco del texto que lo precede */
+  color: var(--pink);
   margin-left: 0.08em;
 }
 .tk-byline {
@@ -215,6 +217,9 @@ body::before {
   font-size: 17px;
   color: var(--ink);
   margin-top: 10px;
+}
+.tk-byline .band {
+  color: var(--pink);
 }
 .tk-meta {
   text-align: center;


### PR DESCRIPTION
## Summary
Updated the ticket system's title and byline styling to improve visual hierarchy and readability by redistributing the pink accent color across multiple elements.

## Changes
- **Title styling**: Moved pink color from `.l2` (main title) to `.l1` (subtitle) and `.num` (number) for better visual balance
- **Title color**: Changed `.l2` from pink to ink color to create contrast with the subtitle
- **Byline styling**: Added pink color to the band name within the byline to emphasize the artist name
- **HTML structure**: Wrapped the band name in a `<span class="band">` to enable targeted styling

## Implementation Details
The changes maintain the existing design system by using CSS custom properties (`var(--pink)` and `var(--ink)`) and follow the BEM-like naming convention with the new `.tk-byline .band` selector. The visual hierarchy now emphasizes both the subtitle and the artist name with the pink accent color, while the main title uses the ink color for contrast.

https://claude.ai/code/session_019gbZigKjmU9EJzE6sHSimJ