### PR TITLE
Add ticket purchase button and event page integration

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -411,6 +411,20 @@ body {
   transform: translateY(-2px);
 }
 
+.btn-tickets {
+  background: var(--color-text-primary);
+  color: var(--color-text-dark);
+  border: 2px solid var(--color-text-primary);
+  box-shadow: var(--shadow-md);
+}
+
+.btn-tickets:hover {
+  background: transparent;
+  color: var(--color-text-primary);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
 .btn:focus-visible {
   outline: 3px solid var(--color-accent);
   outline-offset: 3px;

--- a/public/assets/js/config.js
+++ b/public/assets/js/config.js
@@ -69,6 +69,12 @@ export const CONFIG = {
     platform: 'Cuanto'
   },
 
+  // Tickets (separate ticket-system app)
+  tickets: {
+    name: 'Comprar Entradas',
+    url: 'https://entradas.stilllouder.space/'
+  },
+
   // Analytics Configuration
   analytics: {
     id: 'G-ZZ4XG8CD88',

--- a/public/assets/js/config.js
+++ b/public/assets/js/config.js
@@ -72,7 +72,7 @@ export const CONFIG = {
   // Tickets (separate ticket-system app)
   tickets: {
     name: 'Comprar Entradas',
-    url: 'https://entradas.stilllouder.space/'
+    url: 'https://entradas.stilllouder.space/when-we-were-young-3'
   },
 
   // Analytics Configuration

--- a/public/index.html
+++ b/public/index.html
@@ -382,7 +382,7 @@
               Escuchar Ahora
             </a>
             <a
-              href="https://entradas.stilllouder.space/"
+              href="https://entradas.stilllouder.space/when-we-were-young-3"
               class="btn btn-tickets"
               id="tickets-link"
               target="_blank"

--- a/public/index.html
+++ b/public/index.html
@@ -381,6 +381,36 @@
               </svg>
               Escuchar Ahora
             </a>
+            <a
+              href="https://entradas.stilllouder.space/"
+              class="btn btn-tickets"
+              id="tickets-link"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Comprar entradas para el próximo evento (se abre en nueva ventana)"
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  d="M2 9a3 3 0 0 1 0 6v2a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-2a3 3 0 0 1 0-6V7a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2z"
+                ></path>
+                <path d="M13 5v2"></path>
+                <path d="M13 17v2"></path>
+                <path d="M13 11v2"></path>
+              </svg>
+              Comprar Entradas
+            </a>
             <button class="btn btn-secondary" id="share-btn" aria-label="Compartir">
               <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/ticket-system/src/entradas/App.tsx
+++ b/ticket-system/src/entradas/App.tsx
@@ -71,7 +71,7 @@ export default function App() {
     <div className="tk-page">
       <Decorations />
       <div className="tk-wrap">
-        <p className="tk-kicker tk-reveal">★ {EVENT.band} presenta · tributo emo ♥ ★</p>
+        <p className="tk-kicker tk-reveal">★ {EVENT.band} presenta ★</p>
 
         {/* Hero: identidad del evento sobre parche de papel inclinado */}
         <div className="tk-title-block tk-reveal">

--- a/ticket-system/vercel.json
+++ b/ticket-system/vercel.json
@@ -8,6 +8,9 @@
   "crons": [
     { "path": "/api/admin/orders/cleanup", "schedule": "0 6 * * *" }
   ],
+  "rewrites": [
+    { "source": "/when-we-were-young-3", "destination": "/entradas" }
+  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
Adds a ticket purchase button to the main landing page and integrates the separate ticket system application with a new event page rewrite.

## Changes

### Main Site (`public/`)
- **Added ticket purchase button** in the hero section next to the "Escuchar Ahora" link
  - Links to `https://entradas.stilllouder.space/when-we-were-young-3`
  - Styled with `.btn-tickets` class (inverted colors on hover)
  - Includes ticket icon SVG and proper accessibility attributes
- **Added `.btn-tickets` CSS styles** with hover effects matching the design system
- **Updated `config.js`** to include ticket system configuration for centralized URL management

### Ticket System (`ticket-system/`)
- **Added URL rewrite** in `vercel.json` to route `/when-we-were-young-3` to `/entradas`
- **Updated event kicker text** in `App.tsx` to remove "tributo emo ♥" subtitle, keeping only the band name

## Implementation Details
- The ticket button uses the same button styling patterns as other CTAs on the page
- External link properly configured with `target="_blank"` and `rel="noopener noreferrer"`
- SVG icon is marked as decorative with `aria-hidden="true"` and `focusable="false"`
- Ticket system URL is centralized in `config.js` following project conventions
- The URL rewrite allows the ticket system to handle event-specific pages while maintaining clean URLs

https://claude.ai/code/session_01LrhVCKYE76dXoTT9RkQuT9