### PR TITLE
Add dedicated Tickets section with event details

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -742,6 +742,105 @@ body {
 }
 
 /* ============================================
+   TICKETS SECTION
+   ============================================ */
+
+.section-tickets {
+  background: var(--color-bg-tertiary);
+}
+
+.ticket-card {
+  display: grid;
+  grid-template-columns: 1.5fr 1fr;
+  gap: var(--spacing-3xl);
+  align-items: center;
+  max-width: 900px;
+  margin: 0 auto;
+  padding: var(--spacing-3xl);
+}
+
+.ticket-card:hover {
+  transform: none;
+}
+
+.ticket-card__kicker {
+  font-size: var(--font-size-sm);
+  text-transform: uppercase;
+  letter-spacing: var(--letter-spacing-wider);
+  color: var(--color-accent);
+  margin-bottom: var(--spacing-xs);
+}
+
+.ticket-card__event {
+  font-family: var(--font-display);
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-normal);
+  letter-spacing: var(--letter-spacing-wide);
+  line-height: var(--line-height-tight);
+  margin-bottom: var(--spacing-sm);
+}
+
+.ticket-card__tagline {
+  font-size: var(--font-size-md);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--spacing-xl);
+}
+
+.ticket-meta {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-lg);
+}
+
+.ticket-meta__item {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.ticket-meta__item svg {
+  flex-shrink: 0;
+  color: var(--color-accent);
+}
+
+.ticket-meta__text {
+  display: flex;
+  flex-direction: column;
+  line-height: var(--line-height-snug);
+}
+
+.ticket-meta__sub {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.ticket-card__cta {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-md);
+}
+
+.ticket-card__cta .btn-tickets {
+  width: 100%;
+}
+
+.ticket-card__note {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  text-align: center;
+}
+
+@media (max-width: 768px) {
+  .ticket-card {
+    grid-template-columns: 1fr;
+    gap: var(--spacing-xl);
+    padding: var(--spacing-xl);
+  }
+}
+
+/* ============================================
    ABOUT SECTION
    ============================================ */
 

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -320,6 +320,17 @@ const initPlatformTracking = () => {
       });
     });
   }
+
+  // Tickets link tracking
+  const ticketsLink = document.getElementById('tickets-link');
+  if (ticketsLink) {
+    ticketsLink.addEventListener('click', () => {
+      trackEvent('click_tickets', {
+        event_category: 'tickets',
+        event_label: 'when-we-were-young-3'
+      });
+    });
+  }
 };
 
 // ============================================

--- a/public/index.html
+++ b/public/index.html
@@ -316,6 +316,7 @@
         <nav class="header-nav" aria-label="Navegación principal">
           <a href="#hero" class="nav-link active" data-section="hero">Inicio</a>
           <a href="#escuchar" class="nav-link" data-section="escuchar">Escuchar</a>
+          <a href="#entradas" class="nav-link" data-section="entradas">Entradas</a>
           <a href="#about" class="nav-link" data-section="about">Banda</a>
           <a href="#conectar" class="nav-link" data-section="conectar">Conectar</a>
         </nav>
@@ -332,6 +333,7 @@
       <nav class="mobile-nav" aria-label="Navegación móvil">
         <a href="#hero" class="mobile-nav-link" data-section="hero">Inicio</a>
         <a href="#escuchar" class="mobile-nav-link" data-section="escuchar">Escuchar</a>
+        <a href="#entradas" class="mobile-nav-link" data-section="entradas">Entradas</a>
         <a href="#about" class="mobile-nav-link" data-section="about">Banda</a>
         <a href="#conectar" class="mobile-nav-link" data-section="conectar">Conectar</a>
       </nav>
@@ -380,36 +382,6 @@
                 <path d="M8 5v14l11-7z" />
               </svg>
               Escuchar Ahora
-            </a>
-            <a
-              href="https://entradas.stilllouder.space/when-we-were-young-3"
-              class="btn btn-tickets"
-              id="tickets-link"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Comprar entradas para el próximo evento (se abre en nueva ventana)"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                width="20"
-                height="20"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                stroke-width="2"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                aria-hidden="true"
-                focusable="false"
-              >
-                <path
-                  d="M2 9a3 3 0 0 1 0 6v2a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-2a3 3 0 0 1 0-6V7a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2z"
-                ></path>
-                <path d="M13 5v2"></path>
-                <path d="M13 17v2"></path>
-                <path d="M13 11v2"></path>
-              </svg>
-              Comprar Entradas
             </a>
             <button class="btn btn-secondary" id="share-btn" aria-label="Compartir">
               <svg
@@ -644,6 +616,135 @@
               <span class="platform-action">Reproducir</span>
             </a>
           </nav>
+        </div>
+      </section>
+
+      <!-- Tickets Section -->
+      <section class="section section-tickets" id="entradas">
+        <div class="section-container">
+          <header class="section-header">
+            <h2 class="section-title reveal-up">Entradas</h2>
+            <p class="section-subtitle reveal-up">Nos subimos al escenario — no te quedes fuera</p>
+          </header>
+
+          <div class="ticket-card glass-card reveal-up">
+            <div class="ticket-card__main">
+              <p class="ticket-card__kicker">Still Louder en vivo</p>
+              <h3 class="ticket-card__event">When We Were Young 3</h3>
+              <p class="ticket-card__tagline">
+                Una noche emo &amp; pop-punk para gritar a todo pulmón
+              </p>
+
+              <ul class="ticket-meta">
+                <li class="ticket-meta__item">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="22"
+                    height="22"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                    focusable="false"
+                  >
+                    <rect x="3" y="4" width="18" height="18" rx="2" ry="2"></rect>
+                    <line x1="16" y1="2" x2="16" y2="6"></line>
+                    <line x1="8" y1="2" x2="8" y2="6"></line>
+                    <line x1="3" y1="10" x2="21" y2="10"></line>
+                  </svg>
+                  <span class="ticket-meta__text">
+                    <strong>Sábado 1 de agosto, 2026</strong>
+                    <span class="ticket-meta__sub">8:00 PM</span>
+                  </span>
+                </li>
+                <li class="ticket-meta__item">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="22"
+                    height="22"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                    focusable="false"
+                  >
+                    <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z"></path>
+                    <circle cx="12" cy="10" r="3"></circle>
+                  </svg>
+                  <span class="ticket-meta__text">
+                    <strong>Hops Food &amp; Drinks</strong>
+                    <span class="ticket-meta__sub">David, Chiriquí</span>
+                  </span>
+                </li>
+                <li class="ticket-meta__item">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="22"
+                    height="22"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    aria-hidden="true"
+                    focusable="false"
+                  >
+                    <path
+                      d="M2 9a3 3 0 0 1 0 6v2a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-2a3 3 0 0 1 0-6V7a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2z"
+                    ></path>
+                    <path d="M13 5v2"></path>
+                    <path d="M13 17v2"></path>
+                    <path d="M13 11v2"></path>
+                  </svg>
+                  <span class="ticket-meta__text">
+                    <strong>Preventa desde $6</strong>
+                    <span class="ticket-meta__sub">General $8 el día del evento</span>
+                  </span>
+                </li>
+              </ul>
+            </div>
+
+            <div class="ticket-card__cta">
+              <a
+                href="https://entradas.stilllouder.space/when-we-were-young-3"
+                class="btn btn-tickets"
+                id="tickets-link"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Comprar entradas para When We Were Young 3 (se abre en nueva ventana)"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  aria-hidden="true"
+                  focusable="false"
+                >
+                  <path
+                    d="M2 9a3 3 0 0 1 0 6v2a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-2a3 3 0 0 1 0-6V7a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2z"
+                  ></path>
+                  <path d="M13 5v2"></path>
+                  <path d="M13 17v2"></path>
+                  <path d="M13 11v2"></path>
+                </svg>
+                Comprar Entradas
+              </a>
+              <p class="ticket-card__note">Compra directa con la banda · pago seguro</p>
+            </div>
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary

Refactors the ticket purchasing flow by moving the "Comprar Entradas" button from the hero section into a dedicated, full-featured Tickets section. This provides better visual hierarchy and allows for rich event information display.

## Key Changes

- **Navigation updates**: Added "Entradas" link to both desktop and mobile navigation menus, positioned between "Escuchar" and "Banda"
- **New Tickets section**: Created a dedicated `section-tickets` with a prominent ticket card displaying:
  - Event name and tagline ("When We Were Young 3")
  - Event metadata (date, time, location, pricing) with icons
  - Call-to-action button linking to the ticket purchase page
  - Supportive note about secure payment
- **Hero section cleanup**: Removed the tickets button from the hero section to reduce visual clutter and focus on the primary action (listen now)
- **Styling**: Added comprehensive CSS for the ticket card with:
  - Two-column grid layout (event info + CTA) that stacks on mobile
  - Glass-card styling consistent with the design system
  - Proper spacing and typography using CSS variables
  - Responsive breakpoint at 768px
- **Analytics tracking**: Added GA4 event tracking for ticket link clicks with event category and label

## Implementation Details

- The ticket card uses a grid layout (`1.5fr 1fr`) to balance event details with the call-to-action
- Event metadata is structured as a semantic list with SVG icons for visual interest
- The section maintains consistency with existing design tokens and spacing variables
- Mobile responsiveness collapses the grid to a single column layout
- Accessibility maintained with proper ARIA labels and semantic HTML

https://claude.ai/code/session_01RkXRqmjfzUpNzXPt8Qu8MY