### PR TITLE
fix: allow Firebase/Google endpoints in ticket-system CSP for Yappy

### DIFF
--- a/ticket-system/vercel.json
+++ b/ticket-system/vercel.json
@@ -17,7 +17,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://*.yappy.cloud https://*.yappycloud.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.yappy.cloud https://*.yappycloud.com; connect-src 'self' https://*.supabase.co https://*.yappy.cloud https://*.yappycloud.com https://apipagosbg.bgeneral.cloud; font-src 'self' data: https://*.yappy.cloud https://*.yappycloud.com; frame-src https://*.yappy.cloud https://*.yappycloud.com; media-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
+          "value": "default-src 'self'; script-src 'self' https://*.yappy.cloud https://*.yappycloud.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.yappy.cloud https://*.yappycloud.com; connect-src 'self' https://*.supabase.co https://*.yappy.cloud https://*.yappycloud.com https://apipagosbg.bgeneral.cloud https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com; font-src 'self' data: https://*.yappy.cloud https://*.yappycloud.com; frame-src https://*.yappy.cloud https://*.yappycloud.com; media-src 'self' blob:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
         },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },


### PR DESCRIPTION
The Yappy Botón de Pago web component authenticates against
identitytoolkit/securetoken and subscribes to the transaction status in
Firestore (firestore.googleapis.com) to drive its success/error UI. The
CSP connect-src didn't whitelist these Google/Firebase endpoints, so the
realtime listener was blocked: the payment and server-side IPN succeeded,
but the component timed out and showed its generic 'Algo no salió como
esperábamos' modal in the browser.

Add *.googleapis.com and *.firebaseio.com (incl. wss) to connect-src.