### PR TITLE
docs: refresh root README as repo's public face

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,359 +1,237 @@
-# Still Louder - Al Vacío
+# Still Louder — Al Vacío
 
-Official website for Still Louder's single "Al Vacío". A modern, performant, and accessible web experience built with progressive enhancement principles.
+Official website for **Still Louder**, a Panamanian rock band, promoting their
+single **"Al Vacío"**. A modern, fast, and accessible landing page built with
+progressive-enhancement principles that links fans to every streaming platform.
+
+🌐 **Live:** https://stilllouder.space/
+
+---
+
+## What's in this repository
+
+This repo holds **two independent applications** that share a single git history
+but deploy as **separate Vercel projects** to **different domains**:
+
+| | Main site | Ticket system |
+|---|---|---|
+| **Location** | repo root (`public/`, `scripts/`, …) | [`ticket-system/`](ticket-system/) |
+| **Purpose** | Static landing page for "Al Vacío" | Ticket sales, issuance & gate validation |
+| **Stack** | Vite + vanilla ES6 modules + CSS | Vite + React + TypeScript + serverless API |
+| **Domain** | https://stilllouder.space/ | https://entradas.stilllouder.space |
+
+The two apps have **independent** build configs, dependencies, security headers,
+and `public/` directories — a change in one does not affect the other. This
+README documents the **main site**. For the ticketing app, see
+[`ticket-system/README.md`](ticket-system/README.md).
+
+---
 
 ## Features
 
-### Current Release (Phase 1, 5 & 6 Complete)
-
-- **Optimized Performance**
-  - Vite build system with code splitting
-  - Image optimization (WebP, AVIF formats)
+- **Performance**
+  - Vite build with code splitting and minification (Terser)
+  - Image optimization (WebP / AVIF) via Sharp
   - Lazy loading for images
-  - Gzip and Brotli compression
-  - Minified CSS and JavaScript
+  - Gzip and Brotli precompression
 
-- **Enhanced User Experience**
-  - Loading states with skeleton loaders
-  - Smooth animations with stagger effects
-  - Ripple effects on button clicks
-  - Web Share API for native sharing
+- **Progressive Web App**
+  - Service Worker with per-resource caching strategies
+  - Offline fallback page
+  - Installable web app manifest
+
+- **User Experience**
+  - Skeleton loading states and staggered animations
+  - Web Share API with clipboard fallback
   - Toast notifications for feedback
-  - Respects `prefers-reduced-motion` for accessibility
+  - Respects `prefers-reduced-motion`
 
-- **Comprehensive Analytics**
-  - Platform click tracking (Spotify, Apple Music, YouTube, Deezer, Amazon)
-  - Social media engagement tracking
-  - Audio player event tracking
-  - Scroll depth monitoring
-  - Time on page tracking
+- **Analytics (Google Analytics 4)**
+  - Streaming platform and social click tracking
+  - Audio player, scroll depth, and engagement-time events
   - Error tracking
 
-- **Robust Architecture**
-  - Modular ES6 modules
-  - Centralized configuration
-  - Global error handling
-  - CSS variables design system
-  - Code quality enforcement (ESLint, Prettier)
+- **Security**
+  - Strict Content Security Policy and security headers (`vercel.json`)
+  - HSTS, X-Frame-Options, nosniff, restrictive Permissions-Policy
+  - `.well-known/security.txt` contact info
 
-- **Accessibility**
-  - WCAG 2.1 Level AA compliant
-  - Keyboard navigation support
-  - Screen reader optimized
-  - ARIA labels throughout
-  - Reduced motion support
+- **SEO & Accessibility**
+  - WCAG 2.1 Level AA compliant, full keyboard navigation, ARIA labels
+  - Sitemap, robots.txt, structured metadata
+
+- **Maintainable Architecture**
+  - Modular ES6 modules with a centralized config
+  - CSS custom-property design system
+  - Code quality enforced with ESLint + Prettier
+
+---
 
 ## Technology Stack
 
-- **Build Tool:** Vite 5.x
-- **JavaScript:** ES6+ Modules
-- **Styling:** CSS3 with Variables
-- **Analytics:** Google Analytics 4
-- **Code Quality:** ESLint, Prettier
-- **Compression:** Gzip, Brotli
+| Technology | Purpose |
+|------------|---------|
+| Vite 7 | Build tool (hot reload, minification, compression) |
+| ES6 Modules | JavaScript module system |
+| CSS3 | Styling with CSS custom properties |
+| Sharp | Image optimization |
+| ESLint + Prettier | Linting and formatting |
+| Google Analytics 4 | Analytics |
+| Vercel | Hosting & deployment |
+
+**Required Node.js version:** >= 18
+
+---
 
 ## Project Structure
 
 ```
 still-louder-site/
-├── public/
+├── public/                          # Vite root (source files)
 │   ├── assets/
 │   │   ├── css/
-│   │   │   ├── variables.css          # Design system tokens
-│   │   │   ├── style.css              # Main styles
-│   │   │   └── al-vacio-pre-release/  # Pre-release page styles
+│   │   │   ├── variables.css         # Design system tokens
+│   │   │   ├── style.css             # Main styles
+│   │   │   └── al-vacio-pre-release/ # Pre-release page styles
 │   │   ├── js/
-│   │   │   ├── config.js              # Centralized configuration
-│   │   │   ├── analytics.js           # Analytics tracking
-│   │   │   ├── share.js               # Web Share API
-│   │   │   ├── error-handler.js       # Error management
-│   │   │   ├── ui-utils.js            # UI utilities
-│   │   │   └── al-vacio-pre-release/  # Pre-release page scripts
-│   │   └── images/                    # Optimized images
-│   ├── index.html                     # Main landing page
-│   └── al-vacio-pre-release.html      # Pre-release page
-├── scripts/
-│   └── optimize-images.js             # Image optimization script
-├── .eslintrc.json                     # ESLint configuration
-├── .prettierrc                        # Prettier configuration
-├── vite.config.js                     # Vite configuration
-├── package.json                       # Dependencies and scripts
-├── PLAN_DE_MEJORAS.md                 # Improvement plan
-├── PHASE_5_6_IMPLEMENTATION.md        # Implementation details
-└── SUMMARY.md                         # Quick summary
+│   │   │   ├── config.js             # Centralized configuration
+│   │   │   ├── analytics.js          # GA4 tracking
+│   │   │   ├── share.js              # Web Share API
+│   │   │   ├── error-handler.js      # Global error handling
+│   │   │   ├── ui-utils.js           # UI utilities
+│   │   │   ├── sw-register.js        # Service Worker registration
+│   │   │   └── al-vacio-pre-release/ # Pre-release page scripts
+│   │   ├── images/                   # Optimized images (WebP/AVIF)
+│   │   ├── site.webmanifest          # PWA manifest
+│   │   └── links.json                # Platform links data
+│   ├── .well-known/security.txt      # Security contact
+│   ├── index.html                    # Main landing page
+│   ├── al-vacio-pre-release.html     # Pre-release page
+│   ├── offline.html                  # Offline fallback
+│   ├── sw.js                         # Service Worker
+│   ├── sitemap.xml                   # SEO sitemap
+│   └── robots.txt                    # Crawler directives
+├── scripts/optimize-images.js        # Image optimization script
+├── ticket-system/                    # Separate ticketing app (own README)
+├── vite.config.js                    # Build configuration
+├── vercel.json                       # Security headers & caching
+└── package.json                      # Dependencies and scripts
 ```
+
+---
 
 ## Getting Started
 
 ### Prerequisites
 
 - Node.js 18+ and npm
-- Modern web browser
+- A modern web browser
 
 ### Installation
 
 ```bash
-# Clone the repository
 git clone https://github.com/RenanDiaz/still-louder-site.git
 cd still-louder-site
-
-# Install dependencies
 npm install
 ```
 
 ### Development
 
 ```bash
-# Start development server with hot reload
 npm run dev
-
-# The site will be available at http://localhost:5173
+# Available at http://localhost:3000 (opens automatically)
 ```
 
 ### Building for Production
 
 ```bash
-# Build optimized production bundle
-npm run build
-
-# Preview production build locally
-npm run preview
+npm run build     # Build optimized bundle to dist/
+npm run preview   # Preview the production build locally
 ```
 
-### Code Quality
+---
 
-```bash
-# Lint JavaScript
-npm run lint
+## Available Scripts
 
-# Auto-fix linting issues
-npm run lint:fix
+| Script | Description |
+|--------|-------------|
+| `npm run dev` | Start the Vite dev server with hot reload |
+| `npm run build` | Build the production bundle to `dist/` |
+| `npm run preview` | Preview the production build locally |
+| `npm run lint` | Run ESLint on JavaScript |
+| `npm run lint:fix` | Auto-fix linting issues |
+| `npm run format` | Format code with Prettier |
+| `npm run format:check` | Check formatting |
+| `npm run validate` | Run lint + format check (run before committing) |
+| `npm run optimize:images` | Optimize images with Sharp |
 
-# Format code with Prettier
-npm run format
-
-# Check formatting
-npm run format:check
-
-# Run all validations
-npm run validate
-```
+---
 
 ## Configuration
 
-### Updating Configuration
-
-Edit `/public/assets/js/config.js` to customize:
+All URLs, settings, and constants are centralized in
+[`public/assets/js/config.js`](public/assets/js/config.js):
 
 ```javascript
 export const CONFIG = {
   platforms: { /* Streaming platform URLs */ },
-  social: { /* Social media links */ },
+  social:    { /* Social media links */ },
   analytics: { /* Google Analytics settings */ },
-  release: { /* Release information */ },
-  site: { /* Site metadata */ },
-  messages: { /* User-facing messages */ },
-  features: { /* Feature flags */ },
-  ui: { /* UI timings and settings */ }
+  release:   { /* Release information */ },
+  site:      { /* Site metadata */ },
+  messages:  { /* User-facing messages */ },
+  features:  { /* Feature flags */ },
+  ui:        { /* UI timings and settings */ }
 };
 ```
 
-### Customizing Design System
+Design tokens (colors, typography, spacing, shadows, transitions) live in
+[`public/assets/css/variables.css`](public/assets/css/variables.css).
 
-Edit `/public/assets/css/variables.css` to change:
-- Colors (primary, secondary, accent)
-- Typography (fonts, sizes, weights)
-- Spacing scale
-- Shadows and borders
-- Transition timings
-- Animation durations
-
-## Modules
-
-### Analytics Module (`analytics.js`)
-
-```javascript
-import analytics from './assets/js/analytics.js';
-
-// Track custom event
-analytics.trackEvent('custom_event', { /* params */ });
-
-// Automatic tracking initialized on page load
-analytics.initAutoTracking();
-```
-
-### Share Module (`share.js`)
-
-```javascript
-import shareManager from './assets/js/share.js';
-
-// Share with Web Share API or clipboard fallback
-await shareManager.share({
-  title: 'Title',
-  text: 'Description',
-  url: 'https://example.com'
-});
-```
-
-### Error Handler (`error-handler.js`)
-
-```javascript
-import errorHandler from './assets/js/error-handler.js';
-
-// Initialize global handlers
-errorHandler.init();
-
-// Handle specific error
-errorHandler.handleError({
-  type: 'custom',
-  message: 'Error message'
-});
-```
-
-### UI Utils (`ui-utils.js`)
-
-```javascript
-import uiUtils from './assets/js/ui-utils.js';
-
-// Add loading state
-uiUtils.addLoadingState(element);
-
-// Remove loading state
-uiUtils.removeLoadingState(element);
-
-// Initialize lazy loading
-uiUtils.initLazyLoading();
-```
-
-## Analytics Events Tracked
-
-- `click_platform` - Streaming platform clicks
-- `social_click` - Social media clicks
-- `audio_play/pause/ended` - Audio player events
-- `scroll_depth` - Scroll milestones (25%, 50%, 75%, 100%)
-- `engagement_time` - Time on page milestones
-- `share` - Share button usage
-- `comment_submit` - Comment submissions
-- `error` - Error occurrences
-
-## Browser Support
-
-- Chrome/Edge (latest)
-- Firefox (latest)
-- Safari (latest)
-- Safari iOS (latest)
-- Chrome Android (latest)
-
-## Performance Metrics
-
-- Lighthouse Performance: 95+
-- First Contentful Paint: < 1.5s
-- Largest Contentful Paint: < 2.5s
-- Time to Interactive: < 3s
-- Total Bundle Size: ~500KB (gzipped)
-
-## Accessibility
-
-- WCAG 2.1 Level AA compliant
-- Keyboard navigation fully supported
-- Screen reader optimized
-- High contrast mode support
-- Reduced motion preferences respected
-- ARIA labels and roles throughout
+---
 
 ## Deployment
 
-The site is optimized for deployment on:
-- Vercel (recommended)
-- Netlify
-- GitHub Pages
-- Any static hosting service
-
-### Vercel Deployment
+The main site auto-deploys to **Vercel** from the `main` branch. Security headers
+and caching rules are defined in [`vercel.json`](vercel.json).
 
 ```bash
-# Install Vercel CLI
 npm i -g vercel
-
-# Deploy
-vercel
+vercel --prod
 ```
+
+The ticket system is deployed as a **separate** Vercel project — see
+[`ticket-system/README.md`](ticket-system/README.md).
+
+---
 
 ## Contributing
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'feat: add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+1. Create a feature branch (`git checkout -b feat/amazing-feature`)
+2. Make your changes and run `npm run validate`
+3. Commit using [Conventional Commits](https://www.conventionalcommits.org/)
+   (`feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `perf:`, `chore:`)
+4. Push the branch and open a Pull Request
 
-### Commit Convention
+For deeper architecture and contribution notes, see
+[`CLAUDE.md`](CLAUDE.md).
 
-We use conventional commits:
-- `feat:` - New feature
-- `fix:` - Bug fix
-- `docs:` - Documentation changes
-- `style:` - Code style changes (formatting, etc)
-- `refactor:` - Code refactoring
-- `perf:` - Performance improvements
-- `test:` - Adding or updating tests
-- `chore:` - Maintenance tasks
+---
 
 ## Documentation
 
-- **PLAN_DE_MEJORAS.md** - Complete 6-phase improvement plan
-- **PHASE_5_6_IMPLEMENTATION.md** - Detailed Phase 5 & 6 documentation
-- **SUMMARY.md** - Quick implementation summary
+| File | Contents |
+|------|----------|
+| [`CLAUDE.md`](CLAUDE.md) | Full architecture & contributor guide |
+| [`SECURITY_SUMMARY.md`](SECURITY_SUMMARY.md) | Security implementation details |
+| [`PWA_IMPLEMENTATION.md`](PWA_IMPLEMENTATION.md) | Service Worker & PWA details |
+| [`SEO_ACCESSIBILITY_SUMMARY.md`](SEO_ACCESSIBILITY_SUMMARY.md) | SEO & accessibility work |
+| [`PHASE_5_6_IMPLEMENTATION.md`](PHASE_5_6_IMPLEMENTATION.md) | UX/UI improvements |
+| [`PLAN_DE_MEJORAS.md`](PLAN_DE_MEJORAS.md) | Complete improvement plan |
 
-## Roadmap
+---
 
-### Phase 1: Performance Optimization ✅
-- Image optimization
-- Build system setup
-- Code minification
-- Caching strategies
-
-### Phase 2: PWA Implementation (Planned)
-- Service Worker
-- Offline support
-- App manifest
-- Installability
-
-### Phase 3: SEO & Accessibility (Planned)
-- Structured data
-- Sitemap
-- Enhanced accessibility
-- Meta tags optimization
-
-### Phase 4: Security (Planned)
-- Content Security Policy
-- Security headers
-- Safe external links
-
-### Phase 5: Refactoring ✅
-- CSS variables
-- Code consolidation
-- Linting setup
-- Documentation
-
-### Phase 6: UX/UI Improvements ✅
-- Loading states
-- Animations
-- Error handling
-- Web Share API
-- Enhanced analytics
-
-## License
-
-All rights reserved - Still Louder © 2025
-
-## Credits
-
-- **Music & Art:** Still Louder
-- **Development:** Still Louder Team
-- **Implementation Support:** Claude Code
-
-## Contact
+## Connect with Still Louder
 
 - Instagram: [@stilllouder](https://www.instagram.com/stilllouder/)
 - Facebook: [stilllouder](https://www.facebook.com/stilllouder/)
@@ -361,6 +239,11 @@ All rights reserved - Still Louder © 2025
 
 ---
 
-**Made with passion for independent music** 🎸
+## License
 
-For support or questions, please open an issue on GitHub.
+Code is distributed under the MIT License (see `package.json`). Music, artwork,
+and brand assets are © Still Louder — all rights reserved.
+
+---
+
+**Made with passion for independent music** 🎸


### PR DESCRIPTION
## Summary

Rewrites the root `README.md` — the repo's public face on GitHub — to be accurate and current. The previous version was outdated in several ways and made no mention of the ticket system.

## Changes

- **Document the two-app monorepo**: clearly explains the repo contains both the **main site** and the **ticket system** (`ticket-system/`), deployed as independent Vercel projects on different domains. The ticket system wasn't mentioned at all before.
- **Correct stack details**: Vite **7** (was 5.x) and dev server on **localhost:3000** (was 5173).
- **Reflect implemented features**: PWA, security headers/CSP, and SEO/accessibility were listed under a "Planned" roadmap despite already being implemented — moved to the features list and dropped the stale roadmap.
- **Update project structure** to match the actual tree (`sw.js`, `offline.html`, `.well-known/security.txt`, `site.webmanifest`, `links.json`, `ticket-system/`).
- **Fix license note** to match `package.json` (MIT for code; music/art © Still Louder), without linking a non-existent `LICENSE` file.
- **Refresh the documentation index** with working relative links to files that actually exist.

## Notes

Docs-only change — no code or build configuration touched.

https://claude.ai/code/session_01FKhKWH27A1RFj5ucEaZAas

---
_Generated by [Claude Code](https://claude.ai/code/session_01FKhKWH27A1RFj5ucEaZAas)_