### PR TITLE
feat: smart preventa/general tier selection on purchase form

### DIFF
--- a/ticket-system/api/_lib/pricing.ts
+++ b/ticket-system/api/_lib/pricing.ts
@@ -12,6 +12,16 @@ export function priceFor(tier: Tier, quantity: number): number {
   return TIER_PRICE_CENTS[tier] * quantity;
 }
 
+// Presale closes at the start of the event day (Panama time, UTC-5); after that
+// only general/day-of pricing is sold, regardless of remaining cupo. Mirrors
+// EVENT.presaleEnd in the client config — duplicated on purpose because the
+// server is authoritative on what can be sold (the same pattern as prices).
+const PRESALE_END_ISO = '2026-08-01T00:00:00-05:00';
+
+export function isPresaleOpenByDate(now: Date = new Date()): boolean {
+  return now.getTime() < new Date(PRESALE_END_ISO).getTime();
+}
+
 // How long a pending order holds its presale cupo before cleanup frees it.
 // Manual methods (cash / CuantoApp) need a generous window because
 // reconciliation is human; Yappy confirms instantly so it can be short.

--- a/ticket-system/api/orders.ts
+++ b/ticket-system/api/orders.ts
@@ -1,7 +1,12 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { getSupabase } from './_lib/supabase.js';
 import { methodNotAllowed, parseBody, sendJson, withErrorHandling } from './_lib/http.js';
-import { MAX_QUANTITY_PER_ORDER, priceFor, reservationMinutesFor } from './_lib/pricing.js';
+import {
+  MAX_QUANTITY_PER_ORDER,
+  isPresaleOpenByDate,
+  priceFor,
+  reservationMinutesFor
+} from './_lib/pricing.js';
 import { sendOrderNotificationEmail } from './_lib/email.js';
 import type { Order, PaymentMethod, Tier } from './_lib/types.js';
 
@@ -70,6 +75,11 @@ export default withErrorHandling(async (req: VercelRequest, res: VercelResponse)
   }
   if (!Number.isInteger(quantity) || quantity < 1 || quantity > MAX_QUANTITY_PER_ORDER) {
     return sendJson(res, 400, { error: 'invalid_quantity' });
+  }
+  // Once the presale window has closed, preventa can no longer be sold — even
+  // if cupo remains. The client falls back to general on this error.
+  if (tier === 'preventa' && !isPresaleOpenByDate()) {
+    return sendJson(res, 409, { error: 'presale_ended' });
   }
 
   // Total is computed server-side; the client cannot influence the price.

--- a/ticket-system/src/entradas/App.tsx
+++ b/ticket-system/src/entradas/App.tsx
@@ -34,7 +34,11 @@ export default function App() {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [phone, setPhone] = useState('');
-  const [tier, setTier] = useState<TierKey>('preventa');
+  // Presale is over once its date passes (independent of the async cupo check).
+  // Default the buyer to general from the first render in that case so they
+  // never see preventa preselected when it can't be bought.
+  const presaleEnded = useMemo(() => Date.now() >= new Date(EVENT.presaleEnd).getTime(), []);
+  const [tier, setTier] = useState<TierKey>(presaleEnded ? 'general' : 'preventa');
   const [quantity, setQuantity] = useState(1);
   const [method, setMethod] = useState<Method>('cuantoapp');
   const [submitting, setSubmitting] = useState(false);
@@ -66,12 +70,15 @@ export default function App() {
   }, [confirmation]);
 
   const presaleSoldOut = presale?.soldOut ?? false;
+  // Preventa can only be bought while its date is open AND cupo remains.
+  const presaleAvailable = !presaleEnded && !presaleSoldOut;
   const total = useMemo(() => TIERS[tier].priceCents * quantity, [tier, quantity]);
 
-  // If presale is sold out, default the buyer to general.
+  // Keep the buyer on a tier they can actually purchase: if presale becomes
+  // unavailable (sold out or its date passed), fall back to general pricing.
   useEffect(() => {
-    if (presaleSoldOut && tier === 'preventa') setTier('general');
-  }, [presaleSoldOut, tier]);
+    if (!presaleAvailable && tier === 'preventa') setTier('general');
+  }, [presaleAvailable, tier]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -90,8 +97,12 @@ export default function App() {
     } catch (err) {
       const code = (err as Error & { code?: string }).code;
       if (code === 'presale_sold_out') {
-        setError('La preventa se agotó. Refresca la página para comprar entrada general.');
+        setError('La preventa se agotó. Te cambiamos a entrada general — revisa el precio antes de continuar.');
+        setTier('general');
         getPresaleStatus().then(setPresale).catch(() => {});
+      } else if (code === 'presale_ended') {
+        setError('La preventa terminó. Te cambiamos a entrada general — revisa el precio antes de continuar.');
+        setTier('general');
       } else if (code === 'invalid_email') {
         setError('Revisa el correo: parece inválido.');
       } else {
@@ -161,7 +172,7 @@ export default function App() {
         <div className="tk-reveal">
           <Countdown />
         </div>
-        <PresaleIndicator presale={presale} />
+        <PresaleIndicator presale={presale} presaleEnded={presaleEnded} />
 
         {/* Formulario: temático pero LEGIBLE (sin filtro rasgado en inputs) */}
         <form className="tk-form tk-reveal" onSubmit={handleSubmit}>
@@ -169,14 +180,21 @@ export default function App() {
 
           <label htmlFor="tier">Tipo de entrada</label>
           <select id="tier" value={tier} onChange={(e) => setTier(e.target.value as TierKey)}>
-            <option value="preventa" disabled={presaleSoldOut}>
+            <option value="preventa" disabled={!presaleAvailable}>
               {TIERS.preventa.label} — {TIERS.preventa.priceLabel}
-              {presaleSoldOut ? ' (agotada)' : ''}
+              {presaleSoldOut ? ' (agotada)' : presaleEnded ? ' (finalizada)' : ''}
             </option>
             <option value="general">
               {TIERS.general.label} — {TIERS.general.priceLabel}
             </option>
           </select>
+          {!presaleAvailable && (
+            <p className="tk-hint">
+              {presaleSoldOut
+                ? 'La preventa se agotó: las entradas se venden al precio general.'
+                : 'La preventa terminó: las entradas se venden al precio general.'}
+            </p>
+          )}
 
           <label htmlFor="quantity">Cantidad</label>
           <select
@@ -232,6 +250,14 @@ export default function App() {
             </div>
           )}
 
+          <p className="tk-price-summary" aria-live="polite">
+            <span className="tk-price-summary__tier">{TIERS[tier].label}</span>
+            <span className="tk-price-summary__calc">
+              {TIERS[tier].priceLabel} × {quantity}
+            </span>
+            <strong className="tk-price-summary__total">${(total / 100).toFixed(2)}</strong>
+          </p>
+
           <button type="submit" className="tk-cta" disabled={submitting}>
             {submitting ? 'Procesando…' : `Comprar — $${(total / 100).toFixed(2)} ⚡`}
           </button>
@@ -265,7 +291,22 @@ function Decorations() {
   );
 }
 
-function PresaleIndicator({ presale }: { presale: PresaleStatusResponse | null }) {
+function PresaleIndicator({
+  presale,
+  presaleEnded
+}: {
+  presale: PresaleStatusResponse | null;
+  presaleEnded: boolean;
+}) {
+  // Date-based end takes priority: once the window closes there's no presale to
+  // count, regardless of the cupo the status endpoint reports.
+  if (presaleEnded) {
+    return (
+      <p className="tk-stock tk-stock--soldout">
+        preventa finalizada — entrada general al precio del día ★
+      </p>
+    );
+  }
   if (!presale) return null;
   if (presale.soldOut) {
     return (

--- a/ticket-system/src/entradas/theme.css
+++ b/ticket-system/src/entradas/theme.css
@@ -408,6 +408,37 @@ body::before {
   margin-top: 6px;
 }
 
+/* Resumen de precio: el comprador siempre ve QUÉ tarifa y CUÁNTO paga antes
+   de enviar (sobre todo cuando cae a precio general por preventa agotada). */
+.tk-price-summary {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  margin: 20px 0 0;
+  padding: 12px 14px;
+  border: 2px dashed var(--ink);
+  border-radius: 4px;
+  font-family: var(--font-body);
+  color: var(--ink);
+}
+.tk-price-summary__tier {
+  font-family: var(--font-patch);
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  font-size: 14px;
+}
+.tk-price-summary__calc {
+  font-size: 14px;
+  color: #5a5468;
+}
+.tk-price-summary__total {
+  font-family: var(--font-patch);
+  font-size: 20px;
+  margin-left: auto;
+}
+
 /* ===================== CTA (botón sticker) ===================== */
 .tk-cta {
   display: block;

--- a/ticket-system/src/shared/config.ts
+++ b/ticket-system/src/shared/config.ts
@@ -8,6 +8,10 @@ export const EVENT = {
   venue: 'Hops',
   // ISO dates (local Panama time, UTC-5).
   presaleStart: '2026-06-15T00:00:00-05:00',
+  // Presale closes at the start of the event day; from then on only the
+  // general/"día del evento" price applies. Mirrored server-side in
+  // api/_lib/pricing.ts (PRESALE_END_ISO) — the server is authoritative.
+  presaleEnd: '2026-08-01T00:00:00-05:00',
   eventDate: '2026-08-01T20:00:00-05:00'
 } as const;
 


### PR DESCRIPTION
Make the ticket form pick the right tier automatically and always show the
buyer the price they'll pay:

- Default to preventa only while the presale is genuinely available (date
  window open AND cupo remaining); otherwise default to general.
- Disable the preventa option with a clear reason ("agotada" when sold out,
  "finalizada" when the date passed) and explain that general pricing applies.
- Add a price summary (tier + unit price x quantity = total) above the CTA so
  the amount is explicit, especially after falling back to general.
- Enforce the presale window server-side: orders.ts rejects preventa with
  `presale_ended` once the date passes, so the rule can't be bypassed; the
  client switches to general and surfaces the new price.
- Add EVENT.presaleEnd (client) mirrored by PRESALE_END_ISO (server).