### PR TITLE
fix: auto-apply best ticket price instead of letting buyers choose tier

### DIFF
--- a/ticket-system/api/orders.ts
+++ b/ticket-system/api/orders.ts
@@ -8,7 +8,7 @@ import {
   reservationMinutesFor
 } from './_lib/pricing.js';
 import { sendOrderNotificationEmail } from './_lib/email.js';
-import type { Order, PaymentMethod, Tier } from './_lib/types.js';
+import type { Order, PaymentMethod, PresaleStatus, Tier } from './_lib/types.js';
 
 const TIERS: Tier[] = ['preventa', 'general'];
 const METHODS: PaymentMethod[] = ['yappy', 'cuantoapp', 'cash'];
@@ -80,6 +80,19 @@ export default withErrorHandling(async (req: VercelRequest, res: VercelResponse)
   // if cupo remains. The client falls back to general on this error.
   if (tier === 'preventa' && !isPresaleOpenByDate()) {
     return sendJson(res, 409, { error: 'presale_ended' });
+  }
+  // The tier is not the buyer's choice: while presale is open and has cupo,
+  // nobody should pay the (higher) general price. This guards against stale
+  // or tampered clients; the current client only sends 'general' when presale
+  // is unavailable. The extra RPC only runs during the presale window.
+  if (tier === 'general' && isPresaleOpenByDate()) {
+    const { data: presaleStatus, error: presaleError } = await getSupabase()
+      .rpc('presale_status')
+      .single<PresaleStatus>();
+    if (presaleError) throw new Error(`presale_status failed: ${presaleError.message}`);
+    if (!presaleStatus!.sold_out) {
+      return sendJson(res, 409, { error: 'presale_available' });
+    }
   }
 
   // Total is computed server-side; the client cannot influence the price.

--- a/ticket-system/src/entradas/App.tsx
+++ b/ticket-system/src/entradas/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   createOrder,
   getOrderStatus,
@@ -35,10 +35,11 @@ export default function App() {
   const [email, setEmail] = useState('');
   const [phone, setPhone] = useState('');
   // Presale is over once its date passes (independent of the async cupo check).
-  // Default the buyer to general from the first render in that case so they
-  // never see preventa preselected when it can't be bought.
-  const presaleEnded = useMemo(() => Date.now() >= new Date(EVENT.presaleEnd).getTime(), []);
-  const [tier, setTier] = useState<TierKey>(presaleEnded ? 'general' : 'preventa');
+  // State (not a constant) so a server-side `presale_ended` rejection — e.g.
+  // a buyer with a skewed clock — can flip it too.
+  const [presaleEnded, setPresaleEnded] = useState(
+    () => Date.now() >= new Date(EVENT.presaleEnd).getTime()
+  );
   const [quantity, setQuantity] = useState(1);
   const [method, setMethod] = useState<Method>('cuantoapp');
   const [submitting, setSubmitting] = useState(false);
@@ -72,13 +73,10 @@ export default function App() {
   const presaleSoldOut = presale?.soldOut ?? false;
   // Preventa can only be bought while its date is open AND cupo remains.
   const presaleAvailable = !presaleEnded && !presaleSoldOut;
-  const total = useMemo(() => TIERS[tier].priceCents * quantity, [tier, quantity]);
-
-  // Keep the buyer on a tier they can actually purchase: if presale becomes
-  // unavailable (sold out or its date passed), fall back to general pricing.
-  useEffect(() => {
-    if (!presaleAvailable && tier === 'preventa') setTier('general');
-  }, [presaleAvailable, tier]);
+  // The tier is never the buyer's choice: while presale is available everyone
+  // pays the cheaper presale price; once it ends or sells out, general applies.
+  const tier: TierKey = presaleAvailable ? 'preventa' : 'general';
+  const total = TIERS[tier].priceCents * quantity;
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -97,12 +95,26 @@ export default function App() {
     } catch (err) {
       const code = (err as Error & { code?: string }).code;
       if (code === 'presale_sold_out') {
-        setError('La preventa se agotó. Te cambiamos a entrada general — revisa el precio antes de continuar.');
-        setTier('general');
+        setError('La preventa se agotó. Ahora aplica el precio general — revisa el total antes de continuar.');
+        // Flip availability locally right away (works even if the status fetch
+        // failed earlier); the refetch then refines the real count.
+        setPresale((p) => ({
+          available: 0,
+          capacity: p?.capacity ?? 0,
+          stage2Active: p?.stage2Active ?? false,
+          soldOut: true
+        }));
         getPresaleStatus().then(setPresale).catch(() => {});
       } else if (code === 'presale_ended') {
-        setError('La preventa terminó. Te cambiamos a entrada general — revisa el precio antes de continuar.');
-        setTier('general');
+        setError('La preventa terminó. Ahora aplica el precio general — revisa el total antes de continuar.');
+        setPresaleEnded(true);
+      } else if (code === 'presale_available') {
+        // The server knows better: presale is open again (freed cupo or our
+        // clock was ahead). Flip back so the buyer pays the cheaper price.
+        setError('¡La preventa está disponible! Aplica su precio — revisa el total antes de continuar.');
+        setPresaleEnded(false);
+        setPresale((p) => (p ? { ...p, available: Math.max(p.available, 1), soldOut: false } : p));
+        getPresaleStatus().then(setPresale).catch(() => {});
       } else if (code === 'invalid_email') {
         setError('Revisa el correo: parece inválido.');
       } else {
@@ -178,23 +190,21 @@ export default function App() {
         <form className="tk-form tk-reveal" onSubmit={handleSubmit}>
           <h2 className="tk-form__title">Compra tus entradas</h2>
 
-          <label htmlFor="tier">Tipo de entrada</label>
-          <select id="tier" value={tier} onChange={(e) => setTier(e.target.value as TierKey)}>
-            <option value="preventa" disabled={!presaleAvailable}>
-              {TIERS.preventa.label} — {TIERS.preventa.priceLabel}
-              {presaleSoldOut ? ' (agotada)' : presaleEnded ? ' (finalizada)' : ''}
-            </option>
-            <option value="general">
-              {TIERS.general.label} — {TIERS.general.priceLabel}
-            </option>
-          </select>
-          {!presaleAvailable && (
-            <p className="tk-hint">
-              {presaleSoldOut
-                ? 'La preventa se agotó: las entradas se venden al precio general.'
-                : 'La preventa terminó: las entradas se venden al precio general.'}
-            </p>
-          )}
+          {/* La tarifa no se elige: se aplica sola la mejor disponible. */}
+          <span className="tk-label" id="tier-label">
+            Tipo de entrada
+          </span>
+          <p className="tk-tier" aria-labelledby="tier-label" aria-live="polite">
+            <span className="tk-tier__name">{TIERS[tier].label}</span>
+            <strong className="tk-tier__price">{TIERS[tier].priceLabel}</strong>
+          </p>
+          <p className="tk-hint">
+            {presaleAvailable
+              ? 'Te aplicamos automáticamente el precio de preventa mientras esté disponible.'
+              : presaleEnded
+                ? 'La preventa terminó: las entradas se venden al precio general.'
+                : 'La preventa se agotó: las entradas se venden al precio general.'}
+          </p>
 
           <label htmlFor="quantity">Cantidad</label>
           <select

--- a/ticket-system/src/entradas/theme.css
+++ b/ticket-system/src/entradas/theme.css
@@ -366,7 +366,8 @@ body::before {
   text-transform: uppercase;
   margin-bottom: 6px;
 }
-.tk-form label {
+.tk-form label,
+.tk-form .tk-label {
   display: block;
   font-family: var(--font-patch);
   font-size: 13px;
@@ -374,6 +375,29 @@ body::before {
   color: var(--ink);
   text-transform: uppercase;
   margin: 16px 0 6px;
+}
+
+/* Tarifa aplicada (solo lectura): la mejor tarifa disponible se asigna sola,
+   el comprador nunca elige pagar de más. */
+.tk-tier {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  margin: 0;
+  padding: 12px 14px;
+  border: 2px solid var(--ink);
+  border-radius: 4px;
+  background: #fff;
+  font-family: var(--font-body);
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--ink);
+}
+.tk-tier__price {
+  font-family: var(--font-patch);
+  font-size: 18px;
+  letter-spacing: 0.5px;
 }
 .tk-form input,
 .tk-form select {


### PR DESCRIPTION
The tier selector let buyers pick general ($8) while preventa ($6) was
still available, which makes no sense — nobody should opt into paying
more. The tier is now derived, never chosen:

- Replace the "Tipo de entrada" select with a read-only display of the
  applied tier: preventa while it's open and has cupo, general otherwise.
- Server now rejects 'general' orders while presale is open with cupo
  (presale_available, 409), mirroring the existing presale_ended guard,
  so stale or tampered clients can't overpay either.
- Client handles presale_available by flipping back to preventa pricing
  and refreshing the cupo status.