### PR TITLE
feat: use Yappy brand blue theme for payment button

### DIFF
--- a/ticket-system/src/entradas/YappyButton.tsx
+++ b/ticket-system/src/entradas/YappyButton.tsx
@@ -139,6 +139,8 @@ export function YappyButton({ orderId, cdnUrl, onPaymentSent, onError }: YappyBu
     );
   }
 
-  // Brand button (no recoloring allowed); dark theme matches the page.
-  return <btn-yappy ref={ref} theme="dark" rounded="true" />;
+  // Brand button: Yappy only allows its official themes (blue, darkBlue,
+  // orange, dark, sky, light), no custom recoloring. "blue" is the
+  // characteristic Yappy look and stands out on the white card.
+  return <btn-yappy ref={ref} theme="blue" rounded="true" />;
 }


### PR DESCRIPTION
The dark theme rendered as a gray pill that neither matched the page
design nor looked like Yappy. Yappy only allows its official button
themes (blue, darkBlue, orange, dark, sky, light) — no custom
recoloring — so switch to the characteristic brand blue, which is
recognizable and stands out on the white card.

https://claude.ai/code/session_01S1Zcka3ES2Q5errH71miCP