### PR TITLE
fix: serve /api/admin/* via fixed function + rewrite (catch-all 404s on Vercel)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,10 @@ There is no test suite; `npm run typecheck` is the validation gate. The root
   QR rendering, email, pricing, issuance, Yappy adapter). **Nothing in
   `api/_lib/` may ever be imported by client code.** Vercel Hobby caps a
   deployment at **12 serverless functions**, so ALL `/api/admin/*` routes share
-  one catch-all (`api/admin/[...path].ts`); count functions before adding a
-  file under `api/`.
+  one function (`api/admin.ts`) reached via a `vercel.json` rewrite
+  (`/api/admin/:path*` → `/api/admin?path=...`) — catch-all `[...path].ts`
+  files do NOT work outside Next.js; count functions before adding a file
+  under `api/`.
 - **Database**: `supabase/migrations/` — schema with RLS enabled and no
   policies (only the service-role key can access) plus atomic RPCs
   (`create_order`, `mark_order_paid`, `validate_ticket`, `presale_status`,

--- a/ticket-system/README.md
+++ b/ticket-system/README.md
@@ -45,7 +45,7 @@ ticket-system/
 │   ├── presale/status.ts     # GET   /api/presale/status         (público)
 │   ├── tickets/validate.ts   # POST  /api/tickets/validate       (staff)
 │   ├── tickets/qr.ts         # GET   /api/tickets/qr?t=<token>   (imagen del QR)
-│   ├── admin/[...path].ts    # TODAS las rutas /api/admin/* en una sola función
+│   ├── admin.ts              # TODAS las rutas /api/admin/* en una sola función (rewrite en vercel.json)
 │   ├── yappy/config.ts       # GET   /api/yappy/config           (público, sin secretos)
 │   ├── yappy/create-order.ts # POST  /api/yappy/create-order     (público, scoped a la orden)
 │   └── yappy/ipn.ts          # GET   /api/yappy/ipn              (confirmación firmada de Yappy)
@@ -102,10 +102,13 @@ ver nota abajo):
 
 > **Límite de funciones (Vercel Hobby):** el plan Hobby permite **máx. 12
 > funciones serverless** por deploy y el proyecto está cerca del tope. Por eso
-> TODAS las rutas `/api/admin/*` viven en **un solo catch-all**
-> (`api/admin/[...path].ts`) que enruta internamente (orders, cleanup,
-> mark-paid, cancel, resend-email, stage2, tickets, revoke/unrevoke, courtesy).
-> Antes de añadir un archivo nuevo bajo `api/`, contar las funciones.
+> TODAS las rutas `/api/admin/*` viven en **una sola función** (`api/admin.ts`)
+> que enruta internamente (orders, cleanup, mark-paid, cancel, resend-email,
+> stage2, tickets, revoke/unrevoke, courtesy). Un rewrite en `vercel.json` mapea
+> `/api/admin/:path*` a `/api/admin?path=...` porque Vercel **no soporta
+> archivos catch-all `[...path].ts`** fuera de Next.js (despliegan pero
+> devuelven 404). Antes de añadir un archivo nuevo bajo `api/`, contar las
+> funciones.
 
 ### 2. Variables de entorno
 

--- a/ticket-system/api/admin.ts
+++ b/ticket-system/api/admin.ts
@@ -1,14 +1,18 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { getSupabase } from '../_lib/supabase.js';
-import { isAdmin, isCron } from '../_lib/auth.js';
-import { methodNotAllowed, parseBody, sendJson, withErrorHandling } from '../_lib/http.js';
-import { issueOrder, resendOrderEmail, IssueError } from '../_lib/issue.js';
-import { MAX_QUANTITY_PER_ORDER } from '../_lib/pricing.js';
-import type { Order, PresaleStatus, Ticket } from '../_lib/types.js';
+import { getSupabase } from './_lib/supabase.js';
+import { isAdmin, isCron } from './_lib/auth.js';
+import { methodNotAllowed, parseBody, sendJson, withErrorHandling } from './_lib/http.js';
+import { issueOrder, resendOrderEmail, IssueError } from './_lib/issue.js';
+import { MAX_QUANTITY_PER_ORDER } from './_lib/pricing.js';
+import type { Order, PresaleStatus, Ticket } from './_lib/types.js';
 
-// Single catch-all for EVERY /api/admin/* route. Vercel Hobby caps a deployment
-// at 12 serverless functions and the project sits exactly at that limit, so all
-// admin endpoints share one function instead of one file each:
+// Single function for EVERY /api/admin/* route. Vercel Hobby caps a deployment
+// at 12 serverless functions, so all admin endpoints share one function instead
+// of one file each. Catch-all filenames ([...path].ts) only work in Next.js —
+// in a plain api/ directory they deploy but never match, so requests 404. This
+// file therefore lives at the fixed path /api/admin and a rewrite in
+// vercel.json maps /api/admin/:path* onto it, passing the sub-path in the
+// `path` query param:
 //
 //   GET  /api/admin/orders?q=&status=          order list + sales stats
 //   POST /api/admin/orders/cleanup             cancel expired pendings (also GET, cron)
@@ -30,8 +34,11 @@ const TICKET_TIERS = ['preventa', 'general', 'cortesia'];
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 export default withErrorHandling(async (req: VercelRequest, res: VercelResponse) => {
+  // The rewrite delivers the sub-path slash-joined in `path`
+  // (e.g. "orders/<id>/mark-paid"); split it back into segments.
   const raw = req.query.path;
-  const segments = Array.isArray(raw) ? raw : typeof raw === 'string' ? [raw] : [];
+  const joined = Array.isArray(raw) ? raw.join('/') : typeof raw === 'string' ? raw : '';
+  const segments = joined.split('/').filter(Boolean);
   const route = segments.join('/');
 
   // cleanup is the only route the cron may call; everything else is admin-only.

--- a/ticket-system/src/admin/App.tsx
+++ b/ticket-system/src/admin/App.tsx
@@ -110,8 +110,10 @@ function Gate({
       // A successful listing call doubles as a password check.
       await fetchAdminOrders(password);
       onSuccess();
-    } catch {
-      setError('Contraseña incorrecta.');
+    } catch (err) {
+      const status = (err as Error & { status?: number }).status;
+      if (status === 401) setError('Contraseña incorrecta.');
+      else setError('Error de conexión.');
     } finally {
       setChecking(false);
     }

--- a/ticket-system/vercel.json
+++ b/ticket-system/vercel.json
@@ -9,6 +9,7 @@
     { "path": "/api/admin/orders/cleanup", "schedule": "0 6 * * *" }
   ],
   "rewrites": [
+    { "source": "/api/admin/:path*", "destination": "/api/admin?path=:path*" },
     { "source": "/when-we-were-young-3", "destination": "/entradas" }
   ],
   "headers": [


### PR DESCRIPTION
Vercel only supports [...path] catch-all filenames inside Next.js; in a
plain api/ directory the function deploys but never matches, so every
/api/admin/* request returned 404 and the admin login showed
'Contraseña incorrecta'. Move the router to the fixed path api/admin.ts
and add a vercel.json rewrite that forwards /api/admin/:path* with the
sub-path in the 'path' query param. Also distinguish connection/server
errors from a real 401 on the admin login gate.