### PR TITLE
feat(ticket-system): courtesy tickets now consume presale quota

### DIFF
--- a/ticket-system/README.md
+++ b/ticket-system/README.md
@@ -57,6 +57,7 @@ ticket-system/
 ├── supabase/migrations/0001_init.sql   # schema + RPCs atómicas
 ├── supabase/migrations/0002_yappy_order_ref.sql  # order_ref corto p/ Yappy
 ├── supabase/migrations/0003_admin_panel.sql      # tier 'cortesia' + índice de uso
+├── supabase/migrations/0004_courtesy_presale_quota.sql  # cortesías restan cupo de preventa
 ├── entradas.html · admin.html · validar.html · index.html
 ├── vite.config.ts · vercel.json · .env.example
 ```
@@ -76,9 +77,11 @@ La migración crea `orders`, `event_config`, `tickets`, los índices, activa RLS
 (sin policies → solo el service-role accede) y define las **RPCs atómicas**:
 `create_order`, `mark_order_paid`, `validate_ticket`, `presale_status`,
 `cleanup_expired_orders`, `mark_order_emailed`. La migración `0003` añade el
-tier `cortesia` y el método de pago `courtesy` (entradas de regalo, $0, fuera
-del cupo de preventa) más un índice parcial sobre `tickets.used_at` para el
-check-in en vivo.
+tier `cortesia` y el método de pago `courtesy` (entradas de regalo, $0) más un
+índice parcial sobre `tickets.used_at` para el check-in en vivo. La migración
+`0004` hace que las cortesías pagadas **resten cupo de preventa** (e.g. quedan
+70 y se emiten 5 cortesías → quedan 65); emitirlas nunca se bloquea por cupo,
+pero si lo exceden la preventa aparece agotada.
 
 ## Panel de admin
 
@@ -203,7 +206,7 @@ El secreto vive solo en el servidor; es imposible fabricar entradas válidas sin
 - **Tope de preventa race-safe:** `create_order` toma `... for update` sobre la
   fila única de `event_config`, serializando los chequeos de cupo. No se vende de
   más con Etapa 2 inactiva (75) ni activa (150), contando pagadas + pendientes
-  vigentes.
+  vigentes + cortesías pagadas.
 - **Etapa 2 inmediata:** la capacidad se recalcula en vivo desde `event_config`;
   el toggle abre 75 cupos al instante.
 - **Pending vencida libera cupo:** el conteo de cupo (`presale_status` y

--- a/ticket-system/api/_lib/types.ts
+++ b/ticket-system/api/_lib/types.ts
@@ -39,6 +39,7 @@ export interface PresaleStatus {
   capacity: number;
   paid_count: number;
   pending_count: number;
+  courtesy_count: number;
   committed: number;
   available: number;
   stage2_active: boolean;

--- a/ticket-system/api/admin.ts
+++ b/ticket-system/api/admin.ts
@@ -134,6 +134,7 @@ async function listOrders(req: VercelRequest, res: VercelResponse): Promise<void
       capacity: presale!.capacity,
       paid: presale!.paid_count,
       pending: presale!.pending_count,
+      courtesy: presale!.courtesy_count,
       available: presale!.available,
       stage2Active: presale!.stage2_active,
       soldOut: presale!.sold_out
@@ -355,8 +356,9 @@ interface CourtesyBody {
 
 // Creates a $0 courtesy order and funnels it through the SAME issuance routine
 // as every payment method (pending -> paid via issueOrder), so tickets and the
-// email behave identically to a purchase. Courtesy orders never touch the
-// presale cupo: capacity logic only counts tier='preventa'.
+// email behave identically to a purchase. Paid courtesy orders consume presale
+// cupo (counted by presale_status/create_order since migration 0004), but the
+// admin is never blocked by the cap: overshooting just shows presale sold out.
 async function createCourtesy(req: VercelRequest, res: VercelResponse): Promise<void> {
   const body = parseBody<CourtesyBody>(req);
   const buyerName = (body.buyer_name ?? '').trim();

--- a/ticket-system/src/admin/App.tsx
+++ b/ticket-system/src/admin/App.tsx
@@ -263,6 +263,10 @@ function ResumenTab({ password }: { password: string }) {
             <div className="stat__label">Pendientes</div>
           </div>
           <div className="stat">
+            <div className="stat__value">{stats.presale.courtesy}</div>
+            <div className="stat__label">Cortesías</div>
+          </div>
+          <div className="stat">
             <div className="stat__value">{stats.presale.available}</div>
             <div className="stat__label">Disponibles</div>
           </div>

--- a/ticket-system/src/shared/api.ts
+++ b/ticket-system/src/shared/api.ts
@@ -130,6 +130,7 @@ export interface AdminStats {
     capacity: number;
     paid: number;
     pending: number;
+    courtesy: number;
     available: number;
     stage2Active: boolean;
     soldOut: boolean;

--- a/ticket-system/supabase/migrations/0004_courtesy_presale_quota.sql
+++ b/ticket-system/supabase/migrations/0004_courtesy_presale_quota.sql
@@ -1,0 +1,120 @@
+-- =============================================================================
+-- WWWY3 — Las cortesías restan cupo de preventa
+-- =============================================================================
+-- Cambio de política respecto a 0003: las cortesías SÍ consumen cupo de
+-- preventa (ej.: quedan 70 disponibles y se generan 5 cortesías → quedan 65).
+-- Implementación: presale_status() y create_order() suman también las órdenes
+-- tier = 'cortesia' pagadas dentro del cupo comprometido. No hace falta filtrar
+-- por fecha de emisión: cerrada la preventa por fecha, el tier 'preventa' ya no
+-- se vende (gate en api/orders.ts), así que el contador deja de gatear ventas.
+--
+-- Las cortesías NO se bloquean por cupo — son una decisión deliberada del
+-- admin: si exceden la capacidad, available queda clavado en 0 y la preventa
+-- aparece agotada para el público.
+-- =============================================================================
+
+-- El tipo de retorno cambia (se añade courtesy_count), así que CREATE OR
+-- REPLACE no sirve: hay que dropear y recrear.
+drop function if exists presale_status();
+
+create function presale_status()
+returns table (
+  capacity       int,
+  paid_count     int,
+  pending_count  int,
+  courtesy_count int,
+  committed      int,
+  available      int,
+  stage2_active  boolean,
+  sold_out       boolean
+)
+language plpgsql
+stable
+as $$
+declare
+  v_cfg event_config;
+begin
+  select * into v_cfg from event_config where id = 1;
+
+  capacity := v_cfg.presale_stage1_cap +
+    case when v_cfg.presale_stage2_active then v_cfg.presale_stage2_cap else 0 end;
+
+  select coalesce(sum(quantity), 0) into paid_count
+  from orders where tier = 'preventa' and status = 'paid';
+
+  select coalesce(sum(quantity), 0) into pending_count
+  from orders
+  where tier = 'preventa'
+    and status = 'pending'
+    and reservation_expires_at > now();
+
+  -- Las cortesías se emiten pagadas al instante (nunca quedan pendientes con
+  -- reserva), así que basta con contar las pagadas.
+  select coalesce(sum(quantity), 0) into courtesy_count
+  from orders where tier = 'cortesia' and status = 'paid';
+
+  committed     := paid_count + pending_count + courtesy_count;
+  available     := greatest(capacity - committed, 0);
+  stage2_active := v_cfg.presale_stage2_active;
+  sold_out      := committed >= capacity;
+  return next;
+end;
+$$;
+
+-- Misma definición que 0001 salvo el conteo de cupo comprometido, que ahora
+-- incluye las cortesías pagadas.
+create or replace function create_order(
+  p_buyer_name         text,
+  p_buyer_email        text,
+  p_buyer_phone        text,
+  p_tier               text,
+  p_quantity           int,
+  p_total_cents        int,
+  p_payment_method     text,
+  p_reservation_minutes int
+)
+returns orders
+language plpgsql
+as $$
+declare
+  v_cfg       event_config;
+  v_capacity  int;
+  v_committed int;
+  v_order     orders;
+begin
+  if p_tier = 'preventa' then
+    -- Serialize presale capacity decisions on the single config row.
+    select * into v_cfg from event_config where id = 1 for update;
+
+    v_capacity := v_cfg.presale_stage1_cap +
+      case when v_cfg.presale_stage2_active then v_cfg.presale_stage2_cap else 0 end;
+
+    select coalesce(sum(quantity), 0) into v_committed
+    from orders
+    where (tier = 'preventa'
+           and (status = 'paid'
+                or (status = 'pending' and reservation_expires_at > now())))
+       or (tier = 'cortesia' and status = 'paid');
+
+    if v_committed + p_quantity > v_capacity then
+      raise exception 'PRESALE_SOLD_OUT'
+        using errcode = 'P0001',
+              detail  = format('available=%s requested=%s',
+                               greatest(v_capacity - v_committed, 0), p_quantity);
+    end if;
+  end if;
+
+  insert into orders (
+    buyer_name, buyer_email, buyer_phone, tier, quantity,
+    total_cents, payment_method, status, reservation_expires_at
+  )
+  values (
+    p_buyer_name, p_buyer_email, p_buyer_phone, p_tier, p_quantity,
+    p_total_cents, p_payment_method, 'pending',
+    now() + make_interval(mins => p_reservation_minutes)
+  )
+  returning * into v_order;
+
+  return v_order;
+end;
+$$;


### PR DESCRIPTION
Migration 0004 updates presale_status() and create_order() so paid
'cortesia' orders count against the presale cap (e.g. 70 available and
5 courtesies issued -> 65 available). Courtesy issuance itself is never
blocked by the cap; exceeding it just shows presale as sold out.

Exposes courtesy_count through the admin stats API and shows it in the
Preventa card of the admin panel.

https://claude.ai/code/session_01REnioakVXsrjPw1sjXaGqx