### PR TITLE
Implement service fee breakdown for payment methods

### DIFF
--- a/ticket-system/.env.example
+++ b/ticket-system/.env.example
@@ -27,8 +27,32 @@ ADMIN_PASSWORD=
 STAFF_PASSWORD=
 
 # --- CuantoApp (card payments, manual reconciliation) -----------------------
-# Checkout link shown to buyers who choose card. Optional in M1.
+# CuantoApp es manual y su comisión (4.9% + $0.35 fijo) se cobra POR
+# TRANSACCIÓN, no por entrada. Para cobrar el monto exacto con el recargo ya
+# incluido, crea en el catálogo de CuantoApp un producto OCULTO por cada
+# cantidad (1–10), con el precio "grossed-up" — y, si quieres, sus dos precios
+# (preventa/general): el comprador paga el monto que la web le indica y tú
+# marcas el precio de preventa como agotado al cerrar esa etapa.
+#
+# Pega el link de cada producto en la variable de su cantidad. El servidor
+# elige CUANTOAPP_PAYMENT_URL_<cantidad>; si falta, usa CUANTOAPP_PAYMENT_URL
+# como fallback genérico.
+#
+# Montos de referencia (preventa $6 / general $8), recargo = (neto+0.35)/0.951:
+#   1 entrada  → preventa $6.68  · general $8.79
+#   2 entradas → preventa $12.99 · general $17.20
+#   …          (a más entradas, el fijo de $0.35 se diluye entre todas)
 CUANTOAPP_PAYMENT_URL=
+CUANTOAPP_PAYMENT_URL_1=
+CUANTOAPP_PAYMENT_URL_2=
+CUANTOAPP_PAYMENT_URL_3=
+CUANTOAPP_PAYMENT_URL_4=
+CUANTOAPP_PAYMENT_URL_5=
+CUANTOAPP_PAYMENT_URL_6=
+CUANTOAPP_PAYMENT_URL_7=
+CUANTOAPP_PAYMENT_URL_8=
+CUANTOAPP_PAYMENT_URL_9=
+CUANTOAPP_PAYMENT_URL_10=
 
 # --- Cron ---------------------------------------------------------------------
 # Set this in Vercel so the hourly cleanup cron can authenticate itself.

--- a/ticket-system/README.md
+++ b/ticket-system/README.md
@@ -125,7 +125,10 @@ ORDER_NOTIFICATION_EMAIL      # opcional: aviso interno al registrarse una compr
 TICKET_HMAC_SECRET            # openssl rand -hex 32
 ADMIN_PASSWORD, STAFF_PASSWORD
 CRON_SECRET                   # para el cron de limpieza (openssl rand -hex 16)
-CUANTOAPP_PAYMENT_URL         # opcional (link de pago con tarjeta)
+CUANTOAPP_PAYMENT_URL         # fallback genérico (link de pago con tarjeta)
+CUANTOAPP_PAYMENT_URL_1..10   # un link por cantidad: producto oculto en el catálogo
+                              # de CuantoApp con el precio ya recargado (la comisión
+                              # 4.9%+$0.35 es por transacción, no por entrada). Ver .env.example
 PUBLIC_BASE_URL=https://entradas.stilllouder.space
 # Yappy Botón de Pago V2 (vacías = la opción Yappy se oculta sola)
 YAPPY_BTN_MERCHANT_ID, YAPPY_BTN_SECRET_KEY (base64, se muestra UNA vez)
@@ -225,6 +228,13 @@ El secreto vive solo en el servidor; es imposible fabricar entradas válidas sin
   (`api/_lib/pricing.ts`).
 - **Precios:** se calculan en el servidor a partir de (tier, cantidad); el cliente
   nunca envía montos.
+- **Recargo por método de pago ("Cargo por servicio"):** el comprador paga un
+  precio _grossed-up_ que absorbe la comisión, de modo que el **neto** que recibe
+  la banda = precio base. Fórmula (por transacción, el fijo se aplica una sola
+  vez): `precioFinal = (neto + feeFijo) / (1 − feePorcentual)`, redondeado hacia
+  arriba al centavo. CuantoApp 4.9% + $0.35 · Yappy 1.07% (mín. $0.02) · efectivo
+  sin recargo. Cada orden guarda el desglose `net_cents` / `fee_cents` /
+  `total_cents` (`api/_lib/pricing.ts`, migración `0005`).
 
 ## Yappy — Botón de Pago V2
 

--- a/ticket-system/api/_lib/email.ts
+++ b/ticket-system/api/_lib/email.ts
@@ -267,7 +267,13 @@ export async function sendOrderNotificationEmail(order: Order): Promise<void> {
                     ${phoneRow}
                     ${detailRow('Tipo', escapeHtml(tierLabel))}
                     ${detailRow('Cantidad', `${order.quantity} ${order.quantity === 1 ? 'entrada' : 'entradas'}`)}
-                    ${detailRow('Total', formatMoney(order.total_cents))}
+                    ${
+                      order.fee_cents > 0
+                        ? detailRow('Neto (banda)', formatMoney(order.net_cents)) +
+                          detailRow('Cargo por servicio', formatMoney(order.fee_cents))
+                        : ''
+                    }
+                    ${detailRow('Total cobrado', formatMoney(order.total_cents))}
                     ${detailRow('Pago', escapeHtml(methodLabel))}
                     ${detailRow('Fecha', escapeHtml(formatPanamaDate(order.created_at)))}
                     ${detailRow('Orden', `#${order.id}`)}

--- a/ticket-system/api/_lib/pricing.ts
+++ b/ticket-system/api/_lib/pricing.ts
@@ -13,6 +13,71 @@ export function priceFor(tier: Tier, quantity: number): number {
   return TIER_PRICE_CENTS[tier] * quantity;
 }
 
+// =============================================================================
+// Recargo por método de pago ("Cargo por servicio")
+// =============================================================================
+// El comprador paga un precio "grossed-up" que absorbe la comisión del método,
+// de modo que el NETO que recibe la banda iguala al precio base. La comisión es
+// POR TRANSACCIÓN: el fijo (ej. CuantoApp $0.35) se aplica UNA sola vez sobre la
+// orden completa, no por entrada — por eso el cálculo opera sobre el neto total
+// y nunca multiplica el fijo por la cantidad.
+//
+//   precioFinal = (neto + feeFijo) / (1 − feePorcentual)   [redondeado HACIA
+//                 ARRIBA al centavo, para que el neto nunca quede por debajo]
+//
+// Fuente de los números (junio 2026):
+//   CuantoApp (tarjeta): 4.9% + $0.35 fijo
+//   Yappy:               1.07% (1% + 7% ITBMS sobre ese 1%), sin fijo,
+//                        comisión mínima $0.02
+//   Efectivo / cortesía: sin recargo (precioFinal = neto)
+interface FeeConfig {
+  /** Comisión porcentual como fracción (0.049 = 4.9%). */
+  pct: number;
+  /** Comisión fija por transacción, en centavos. */
+  fixedCents: number;
+  /** Comisión mínima que cobra el procesador, en centavos. */
+  minFeeCents: number;
+}
+
+const PAYMENT_FEES: Record<PaymentMethod, FeeConfig> = {
+  cuantoapp: { pct: 0.049, fixedCents: 35, minFeeCents: 0 },
+  yappy: { pct: 0.0107, fixedCents: 0, minFeeCents: 2 },
+  cash: { pct: 0, fixedCents: 0, minFeeCents: 0 },
+  courtesy: { pct: 0, fixedCents: 0, minFeeCents: 0 }
+};
+
+export interface PriceBreakdown {
+  /** Lo que recibe la banda: precio base × cantidad. */
+  netCents: number;
+  /** Recargo por servicio = totalCents − netCents (lo que cubre la comisión). */
+  feeCents: number;
+  /** Lo que paga el comprador (neto + recargo). */
+  totalCents: number;
+}
+
+/**
+ * Desglose autoritativo del precio para una (tier, cantidad, método). El neto es
+ * siempre el precio base; el total absorbe la comisión del método de pago.
+ */
+export function priceBreakdown(tier: Tier, quantity: number, method: PaymentMethod): PriceBreakdown {
+  const netCents = priceFor(tier, quantity);
+  if (netCents <= 0) return { netCents: 0, feeCents: 0, totalCents: 0 };
+
+  const fee = PAYMENT_FEES[method];
+  // Gross-up por transacción: el fijo se suma una sola vez. Redondeo hacia
+  // arriba al centavo para garantizar neto ≥ base.
+  let totalCents = Math.ceil((netCents + fee.fixedCents) / (1 - fee.pct));
+
+  // Comisión mínima: si el procesador cobra un piso (Yappy $0.02) y el recargo
+  // calculado no lo cubre, el comprador debe cubrir al menos ese piso para que
+  // el neto no caiga por debajo del precio base.
+  if (totalCents - netCents < fee.minFeeCents) {
+    totalCents = netCents + fee.minFeeCents;
+  }
+
+  return { netCents, feeCents: totalCents - netCents, totalCents };
+}
+
 // Presale closes at the start of the event day (Panama time, UTC-5); after that
 // only general/day-of pricing is sold, regardless of remaining cupo. Mirrors
 // EVENT.presaleEnd in the client config — duplicated on purpose because the

--- a/ticket-system/api/_lib/types.ts
+++ b/ticket-system/api/_lib/types.ts
@@ -10,7 +10,12 @@ export interface Order {
   buyer_phone: string | null;
   tier: Tier;
   quantity: number;
+  // total_cents = lo que paga el comprador (incluye el recargo por servicio).
+  // net_cents   = lo que recibe la banda (precio base × cantidad).
+  // fee_cents   = recargo por servicio = total_cents − net_cents.
   total_cents: number;
+  net_cents: number;
+  fee_cents: number;
   payment_method: PaymentMethod;
   payment_ref: string | null;
   status: OrderStatus;

--- a/ticket-system/api/admin.ts
+++ b/ticket-system/api/admin.ts
@@ -113,19 +113,21 @@ async function listOrders(req: VercelRequest, res: VercelResponse): Promise<void
 
   const { data: paidOrders, error: paidErr } = await supabase
     .from('orders')
-    .select('tier, quantity, total_cents, payment_method')
+    .select('tier, quantity, total_cents, net_cents, fee_cents, payment_method')
     .eq('status', 'paid');
   if (paidErr) throw new Error(`stats query failed: ${paidErr.message}`);
 
   const paid = (paidOrders ?? []) as Pick<
     Order,
-    'tier' | 'quantity' | 'total_cents' | 'payment_method'
+    'tier' | 'quantity' | 'total_cents' | 'net_cents' | 'fee_cents' | 'payment_method'
   >[];
   const sumQty = (rows: typeof paid) => rows.reduce((sum, o) => sum + o.quantity, 0);
+  // revenueByMethod reporta el NETO por método (lo que realmente recibe la
+  // banda), no el bruto cobrado: el recargo por servicio solo cubre la comisión.
   const revenueByMethod: Record<string, number> = { yappy: 0, cuantoapp: 0, cash: 0 };
   for (const o of paid) {
     if (o.payment_method in revenueByMethod) {
-      revenueByMethod[o.payment_method] += o.total_cents;
+      revenueByMethod[o.payment_method] += o.net_cents;
     }
   }
 
@@ -142,7 +144,11 @@ async function listOrders(req: VercelRequest, res: VercelResponse): Promise<void
     generalPaid: sumQty(paid.filter((o) => o.tier === 'general')),
     courtesyTickets: sumQty(paid.filter((o) => o.tier === 'cortesia')),
     totalTicketsPaid: sumQty(paid),
-    revenueCents: paid.reduce((sum, o) => sum + o.total_cents, 0),
+    // revenueCents = neto que recibe la banda. feesCents = recargos por servicio
+    // que se fueron en comisiones. grossCents = total cobrado al comprador.
+    revenueCents: paid.reduce((sum, o) => sum + o.net_cents, 0),
+    feesCents: paid.reduce((sum, o) => sum + o.fee_cents, 0),
+    grossCents: paid.reduce((sum, o) => sum + o.total_cents, 0),
     revenueByMethod
   };
 
@@ -382,6 +388,8 @@ async function createCourtesy(req: VercelRequest, res: VercelResponse): Promise<
       tier: 'cortesia',
       quantity,
       total_cents: 0,
+      net_cents: 0,
+      fee_cents: 0,
       payment_method: 'courtesy',
       status: 'pending',
       // Pre-stamping emailed_at makes issueOrder skip the email when the

--- a/ticket-system/api/orders.ts
+++ b/ticket-system/api/orders.ts
@@ -4,7 +4,7 @@ import { methodNotAllowed, parseBody, sendJson, withErrorHandling } from './_lib
 import {
   MAX_QUANTITY_PER_ORDER,
   isPresaleOpenByDate,
-  priceFor,
+  priceBreakdown,
   reservationMinutesFor
 } from './_lib/pricing.js';
 import { sendOrderNotificationEmail } from './_lib/email.js';
@@ -23,16 +23,27 @@ interface CreateOrderBody {
   payment_method?: string;
 }
 
-function paymentInstructions(method: PaymentMethod, totalCents: number) {
+// CuantoApp es manual: cada cantidad (1–10) tiene su propio producto OCULTO en
+// el catálogo, con el precio ya "grossed-up" (porque el fijo de $0.35 es por
+// transacción, no por entrada). El operador crea esos productos una vez y pega
+// sus links en CUANTOAPP_PAYMENT_URL_<n>; aquí elegimos el que corresponde a la
+// cantidad. CUANTOAPP_PAYMENT_URL (sin sufijo) queda como fallback. El producto
+// puede llevar dos precios (preventa/general): el comprador paga el monto exacto
+// que le mostramos, y el admin marca el precio de preventa como agotado al
+// cerrarse esa etapa.
+function cuantoappLinkFor(quantity: number): string {
+  return process.env[`CUANTOAPP_PAYMENT_URL_${quantity}`] ?? process.env.CUANTOAPP_PAYMENT_URL ?? '';
+}
+
+function paymentInstructions(method: PaymentMethod, totalCents: number, quantity: number) {
   const amount = `$${(totalCents / 100).toFixed(2)}`;
   switch (method) {
     case 'cuantoapp':
       return {
         method,
         amount,
-        // Operator pastes the CuantoApp checkout link here via env.
-        link: process.env.CUANTOAPP_PAYMENT_URL ?? '',
-        note: 'Paga con tarjeta a través del enlace de CuantoApp. Tu entrada se envía al confirmar el pago.'
+        link: cuantoappLinkFor(quantity),
+        note: `Paga el monto exacto (${amount}) con tarjeta a través del enlace de CuantoApp. Tu entrada se envía al confirmar el pago.`
       };
     case 'cash':
       return {
@@ -95,8 +106,10 @@ export default withErrorHandling(async (req: VercelRequest, res: VercelResponse)
     }
   }
 
-  // Total is computed server-side; the client cannot influence the price.
-  const totalCents = priceFor(tier, quantity);
+  // El precio se calcula en el servidor; el cliente no puede influir en él. El
+  // total incluye el recargo por servicio que absorbe la comisión del método de
+  // pago, de modo que el neto (precio base × cantidad) lo recibe la banda.
+  const { netCents, feeCents, totalCents } = priceBreakdown(tier, quantity, method);
   const reservationMinutes = reservationMinutesFor(method);
 
   const { data: order, error } = await getSupabase()
@@ -107,6 +120,8 @@ export default withErrorHandling(async (req: VercelRequest, res: VercelResponse)
       p_tier: tier,
       p_quantity: quantity,
       p_total_cents: totalCents,
+      p_net_cents: netCents,
+      p_fee_cents: feeCents,
       p_payment_method: method,
       p_reservation_minutes: reservationMinutes
     })
@@ -132,7 +147,13 @@ export default withErrorHandling(async (req: VercelRequest, res: VercelResponse)
     tier: order!.tier,
     quantity: order!.quantity,
     totalCents: order!.total_cents,
+    // Desglose para mostrar al comprador: neto + "Cargo por servicio" = total.
+    breakdown: {
+      netCents: order!.net_cents,
+      feeCents: order!.fee_cents,
+      totalCents: order!.total_cents
+    },
     reservationExpiresAt: order!.reservation_expires_at,
-    payment: paymentInstructions(method, totalCents)
+    payment: paymentInstructions(method, totalCents, quantity)
   });
 });

--- a/ticket-system/src/admin/App.tsx
+++ b/ticket-system/src/admin/App.tsx
@@ -310,10 +310,15 @@ function ResumenTab({ password }: { password: string }) {
           </div>
           <div className="stat">
             <div className="stat__value">${(stats.revenueCents / 100).toFixed(0)}</div>
-            <div className="stat__label">Ingresos</div>
+            <div className="stat__label">Ingresos netos</div>
           </div>
         </div>
-        <h3 style={{ marginBottom: 8 }}>Ingresos por método de pago</h3>
+        <p className="muted" style={{ marginTop: 4 }}>
+          Cobrado al comprador: <strong>{money(stats.grossCents)}</strong> · de eso,{' '}
+          <strong>{money(stats.feesCents)}</strong> son recargos por servicio que cubren las
+          comisiones de pago. El neto ({money(stats.revenueCents)}) es lo que recibe la banda.
+        </p>
+        <h3 style={{ marginBottom: 8 }}>Ingresos netos por método de pago</h3>
         <table style={{ maxWidth: 360 }}>
           <tbody>
             {Object.entries(stats.revenueByMethod).map(([method, cents]) => (
@@ -491,13 +496,15 @@ function OrdenesTab({ password }: { password: string }) {
 
   function exportCsv() {
     const rows: (string | number | null)[][] = [
-      ['Comprador', 'Correo', 'Teléfono', 'Tipo', 'Cantidad', 'Total', 'Pago', 'Referencia', 'Estado', 'Creada', 'Pagada'],
+      ['Comprador', 'Correo', 'Teléfono', 'Tipo', 'Cantidad', 'Neto', 'Cargo por servicio', 'Total cobrado', 'Pago', 'Referencia', 'Estado', 'Creada', 'Pagada'],
       ...orders.map((o) => [
         o.buyer_name,
         o.buyer_email,
         o.buyer_phone,
         TIER_LABELS[o.tier] ?? o.tier,
         o.quantity,
+        (o.net_cents / 100).toFixed(2),
+        (o.fee_cents / 100).toFixed(2),
         (o.total_cents / 100).toFixed(2),
         METHOD_LABELS[o.payment_method] ?? o.payment_method,
         o.payment_ref,

--- a/ticket-system/src/entradas/App.tsx
+++ b/ticket-system/src/entradas/App.tsx
@@ -8,7 +8,14 @@ import {
   type PresaleStatusResponse,
   type YappyConfigResponse
 } from '../shared/api';
-import { EVENT, PAYMENT_METHODS, TIERS, type TierKey } from '../shared/config';
+import {
+  EVENT,
+  PAYMENT_METHODS,
+  TIERS,
+  formatMoney,
+  priceBreakdown,
+  type TierKey
+} from '../shared/config';
 import { Countdown } from './Countdown';
 import { YappyButton } from './YappyButton';
 
@@ -76,7 +83,9 @@ export default function App() {
   // The tier is never the buyer's choice: while presale is available everyone
   // pays the cheaper presale price; once it ends or sells out, general applies.
   const tier: TierKey = presaleAvailable ? 'preventa' : 'general';
-  const total = TIERS[tier].priceCents * quantity;
+  // El total que paga el comprador incluye el "Cargo por servicio" que absorbe
+  // la comisión del método elegido. Estimación en cliente; el servidor manda.
+  const { netCents, feeCents, totalCents } = priceBreakdown(tier, quantity, method);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -260,16 +269,28 @@ export default function App() {
             </div>
           )}
 
-          <p className="tk-price-summary" aria-live="polite">
-            <span className="tk-price-summary__tier">{TIERS[tier].label}</span>
-            <span className="tk-price-summary__calc">
-              {TIERS[tier].priceLabel} × {quantity}
-            </span>
-            <strong className="tk-price-summary__total">${(total / 100).toFixed(2)}</strong>
-          </p>
+          <div className="tk-price-summary" aria-live="polite">
+            <p className="tk-price-summary__row">
+              <span className="tk-price-summary__tier">{TIERS[tier].label}</span>
+              <span className="tk-price-summary__calc">
+                {TIERS[tier].priceLabel} × {quantity}
+              </span>
+              <span className="tk-price-summary__amount">{formatMoney(netCents)}</span>
+            </p>
+            {feeCents > 0 && (
+              <p className="tk-price-summary__row tk-price-summary__row--fee">
+                <span className="tk-price-summary__tier">Cargo por servicio</span>
+                <span className="tk-price-summary__amount">{formatMoney(feeCents)}</span>
+              </p>
+            )}
+            <p className="tk-price-summary__row tk-price-summary__row--total">
+              <span className="tk-price-summary__tier">Total</span>
+              <strong className="tk-price-summary__total">{formatMoney(totalCents)}</strong>
+            </p>
+          </div>
 
           <button type="submit" className="tk-cta" disabled={submitting}>
-            {submitting ? 'Procesando…' : `Comprar — $${(total / 100).toFixed(2)} ⚡`}
+            {submitting ? 'Procesando…' : `Comprar — ${formatMoney(totalCents)} ⚡`}
           </button>
         </form>
 
@@ -363,6 +384,12 @@ function Confirmation({
             Reservamos {data.quantity} {data.quantity === 1 ? 'entrada' : 'entradas'} por un total de{' '}
             <strong>{data.payment.amount}</strong>.
           </p>
+          {data.breakdown.feeCents > 0 && (
+            <p className="tk-success__breakdown" style={{ fontSize: 14, margin: '0 0 8px' }}>
+              Entradas {formatMoney(data.breakdown.netCents)} + Cargo por servicio{' '}
+              {formatMoney(data.breakdown.feeCents)}
+            </p>
+          )}
 
           {isYappy ? (
             <YappyCheckout data={data} cdnUrl={yappyCdnUrl} onReset={onReset} />

--- a/ticket-system/src/entradas/theme.css
+++ b/ticket-system/src/entradas/theme.css
@@ -435,17 +435,30 @@ body::before {
 /* Resumen de precio: el comprador siempre ve QUÉ tarifa y CUÁNTO paga antes
    de enviar (sobre todo cuando cae a precio general por preventa agotada). */
 .tk-price-summary {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  gap: 6px 12px;
   margin: 20px 0 0;
   padding: 12px 14px;
   border: 2px dashed var(--ink);
   border-radius: 4px;
   font-family: var(--font-body);
   color: var(--ink);
+}
+.tk-price-summary__row {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 6px 12px;
+  margin: 0;
+}
+.tk-price-summary__row + .tk-price-summary__row {
+  margin-top: 6px;
+}
+.tk-price-summary__row--total {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid rgba(21, 18, 28, 0.2);
+}
+.tk-price-summary__row--fee {
+  color: #5a5468;
 }
 .tk-price-summary__tier {
   font-family: var(--font-patch);
@@ -456,6 +469,10 @@ body::before {
 .tk-price-summary__calc {
   font-size: 14px;
   color: #5a5468;
+}
+.tk-price-summary__amount {
+  margin-left: auto;
+  font-size: 14px;
 }
 .tk-price-summary__total {
   font-family: var(--font-patch);

--- a/ticket-system/src/shared/api.ts
+++ b/ticket-system/src/shared/api.ts
@@ -51,11 +51,18 @@ export interface CreateOrderInput {
   payment_method: 'cuantoapp' | 'cash' | 'yappy';
 }
 
+export interface PriceBreakdown {
+  netCents: number;
+  feeCents: number;
+  totalCents: number;
+}
+
 export interface CreateOrderResponse {
   orderId: string;
   tier: string;
   quantity: number;
   totalCents: number;
+  breakdown: PriceBreakdown;
   reservationExpiresAt: string | null;
   payment: { method: string; amount: string; link?: string; note: string };
 }
@@ -116,6 +123,8 @@ export interface AdminOrder {
   tier: string;
   quantity: number;
   total_cents: number;
+  net_cents: number;
+  fee_cents: number;
   payment_method: string;
   payment_ref: string | null;
   status: string;
@@ -138,7 +147,11 @@ export interface AdminStats {
   generalPaid: number;
   courtesyTickets: number;
   totalTicketsPaid: number;
+  // revenueCents = neto que recibe la banda; feesCents = recargos por servicio
+  // (comisiones); grossCents = total cobrado al comprador.
   revenueCents: number;
+  feesCents: number;
+  grossCents: number;
   revenueByMethod: Record<string, number>;
 }
 

--- a/ticket-system/src/shared/config.ts
+++ b/ticket-system/src/shared/config.ts
@@ -37,3 +37,38 @@ export const PAYMENT_METHODS = [
   { value: 'cuantoapp', label: 'Tarjeta (CuantoApp)' },
   { value: 'cash', label: 'Efectivo' }
 ] as const;
+
+export type PaymentMethodKey = (typeof PAYMENT_METHODS)[number]['value'];
+
+// Recargo por método de pago — espejo de api/_lib/pricing.ts (PAYMENT_FEES).
+// SOLO para mostrar el total estimado al comprador; el servidor recalcula y es
+// la fuente de verdad. Mantener en sync con el backend al cambiar comisiones.
+const PAYMENT_FEES: Record<PaymentMethodKey, { pct: number; fixedCents: number; minFeeCents: number }> = {
+  yappy: { pct: 0.0107, fixedCents: 0, minFeeCents: 2 },
+  cuantoapp: { pct: 0.049, fixedCents: 35, minFeeCents: 0 },
+  cash: { pct: 0, fixedCents: 0, minFeeCents: 0 }
+};
+
+export interface PriceBreakdown {
+  netCents: number;
+  feeCents: number;
+  totalCents: number;
+}
+
+// El recargo es POR TRANSACCIÓN: el fijo se aplica una sola vez sobre el neto
+// total, no por entrada. precioFinal = (neto + fijo) / (1 − pct), redondeado
+// hacia arriba al centavo (igual que el servidor) para que el neto ≥ base.
+export function priceBreakdown(tier: TierKey, quantity: number, method: PaymentMethodKey): PriceBreakdown {
+  const netCents = TIERS[tier].priceCents * quantity;
+  if (netCents <= 0) return { netCents: 0, feeCents: 0, totalCents: 0 };
+  const fee = PAYMENT_FEES[method];
+  let totalCents = Math.ceil((netCents + fee.fixedCents) / (1 - fee.pct));
+  if (totalCents - netCents < fee.minFeeCents) {
+    totalCents = netCents + fee.minFeeCents;
+  }
+  return { netCents, feeCents: totalCents - netCents, totalCents };
+}
+
+export function formatMoney(cents: number): string {
+  return `$${(cents / 100).toFixed(2)}`;
+}

--- a/ticket-system/supabase/migrations/0005_price_breakdown.sql
+++ b/ticket-system/supabase/migrations/0005_price_breakdown.sql
@@ -1,0 +1,92 @@
+-- =============================================================================
+-- WWWY3 — Desglose de precio: neto recibido vs. cargo por servicio
+-- =============================================================================
+-- A partir de ahora el comprador paga un precio "grossed-up" que absorbe la
+-- comisión del método de pago, de modo que el NETO que recibe la banda iguala
+-- al precio base ($6 preventa / $8 general). Guardamos el desglose para
+-- reportería interna:
+--
+--   total_cents = lo que paga el comprador (incluye el recargo)
+--   net_cents   = lo que recibe la banda (precio base x cantidad)
+--   fee_cents   = recargo por servicio = total_cents - net_cents
+--
+-- La comisión es POR TRANSACCIÓN (el fijo de CuantoApp $0.35 se aplica una sola
+-- vez sobre la orden completa, no por entrada), así que el cálculo lo hace el
+-- servidor en api/_lib/pricing.ts y pasa los tres valores ya resueltos.
+-- =============================================================================
+
+alter table orders
+  add column if not exists net_cents int not null default 0,
+  add column if not exists fee_cents int not null default 0;
+
+-- Backfill de órdenes existentes: antes de este cambio el total no llevaba
+-- recargo, así que el neto era el total y la comisión efectiva queda en 0
+-- (la comisión real la absorbía la banda; no la reconstruimos retroactivamente).
+update orders
+set net_cents = total_cents,
+    fee_cents = 0
+where net_cents = 0 and fee_cents = 0;
+
+-- --- create_order: ahora recibe el desglose ----------------------------------
+-- La firma cambia (se añaden p_net_cents / p_fee_cents), así que hay que dropear
+-- la versión anterior (0004) antes de recrear: cambiar la lista de argumentos
+-- crea una sobrecarga ambigua en lugar de reemplazar.
+drop function if exists create_order(text, text, text, text, int, int, text, int);
+
+create or replace function create_order(
+  p_buyer_name         text,
+  p_buyer_email        text,
+  p_buyer_phone        text,
+  p_tier               text,
+  p_quantity           int,
+  p_total_cents        int,
+  p_net_cents          int,
+  p_fee_cents          int,
+  p_payment_method     text,
+  p_reservation_minutes int
+)
+returns orders
+language plpgsql
+as $$
+declare
+  v_cfg       event_config;
+  v_capacity  int;
+  v_committed int;
+  v_order     orders;
+begin
+  if p_tier = 'preventa' then
+    -- Serialize presale capacity decisions on the single config row.
+    select * into v_cfg from event_config where id = 1 for update;
+
+    v_capacity := v_cfg.presale_stage1_cap +
+      case when v_cfg.presale_stage2_active then v_cfg.presale_stage2_cap else 0 end;
+
+    select coalesce(sum(quantity), 0) into v_committed
+    from orders
+    where (tier = 'preventa'
+           and (status = 'paid'
+                or (status = 'pending' and reservation_expires_at > now())))
+       or (tier = 'cortesia' and status = 'paid');
+
+    if v_committed + p_quantity > v_capacity then
+      raise exception 'PRESALE_SOLD_OUT'
+        using errcode = 'P0001',
+              detail  = format('available=%s requested=%s',
+                               greatest(v_capacity - v_committed, 0), p_quantity);
+    end if;
+  end if;
+
+  insert into orders (
+    buyer_name, buyer_email, buyer_phone, tier, quantity,
+    total_cents, net_cents, fee_cents, payment_method, status, reservation_expires_at
+  )
+  values (
+    p_buyer_name, p_buyer_email, p_buyer_phone, p_tier, p_quantity,
+    p_total_cents, p_net_cents, p_fee_cents, p_payment_method, 'pending',
+    now() + make_interval(mins => p_reservation_minutes)
+  )
+  returning * into v_order;
+
+  return v_order;
+end;
+$$;


### PR DESCRIPTION
## Summary

Implement transparent price breakdown showing base ticket price vs. service charge, with payment method-specific fee calculations. The buyer now pays a "grossed-up" total that absorbs payment processing fees, while the band receives the base price as net revenue.

## Key Changes

**Database & Backend**
- Add `net_cents` and `fee_cents` columns to `orders` table to track price components separately
- Update `create_order()` RPC to accept and store net/fee breakdown
- Implement `priceBreakdown()` function in `api/_lib/pricing.ts` that calculates:
  - `netCents`: base price × quantity (what the band receives)
  - `feeCents`: service charge covering payment processing fees
  - `totalCents`: what the buyer pays (net + fee)
- Fee calculation per payment method (CuantoApp 4.9% + $0.35 fixed; Yappy 1.07% min $0.02; cash/courtesy $0)
- Formula: `totalCents = ceil((netCents + fixedFee) / (1 - percentageFee))`, rounded up to ensure net ≥ base price

**Frontend**
- Mirror `priceBreakdown()` logic in `src/shared/config.ts` for client-side estimation
- Add `formatMoney()` utility for consistent currency display
- Update price summary UI to show itemized breakdown:
  - Base ticket price (tier × quantity)
  - Service charge (only if > $0)
  - Total amount due
- Update CTA button to display total with fee included

**Admin & Reporting**
- Update admin stats to distinguish:
  - `revenueCents`: net amount band receives
  - `feesCents`: total service charges collected
  - `grossCents`: total charged to buyers
- Update CSV export to include net/fee columns
- Update order notification email to show breakdown when fees apply
- Revenue-by-method reporting now shows net (what band actually receives), not gross

**CuantoApp Integration**
- Support per-quantity payment links (`CUANTOAPP_PAYMENT_URL_1` through `CUANTOAPP_PAYMENT_URL_10`)
- Each link points to a hidden CuantoApp catalog product with the grossed-up price already set
- Server selects the correct link based on quantity; falls back to generic `CUANTOAPP_PAYMENT_URL`
- Buyer pays exact amount shown on web; operator marks presale price as sold out when stage closes

## Implementation Details

- Fee calculation is **per-transaction**: fixed fees apply once to the entire order, not per ticket
- Server is authoritative: client-side calculation is estimation only; server recalculates and stores actual values
- Backfill existing orders: `net_cents = total_cents`, `fee_cents = 0` (pre-change orders had no fee)
- All three price components (`net_cents`, `fee_cents`, `total_cents`) are stored for audit trail and reporting
- Updated `.env.example` with detailed CuantoApp setup instructions and reference amounts

https://claude.ai/code/session_0166XcBzDE9HjiSmCDcAuPKK