### PR TITLE
Add Google Wallet integration for event ticket passes

### DIFF
--- a/ticket-system/.env.example
+++ b/ticket-system/.env.example
@@ -75,3 +75,16 @@ YAPPY_BTN_CDN_URL=
 # --- Optional ----------------------------------------------------------------
 # Public base URL of this deployment, used to build links in emails.
 PUBLIC_BASE_URL=https://entradas.stilllouder.space
+
+# --- Google Wallet (optional — "Add to Google Wallet" button) ----------------
+# Server-only (NO VITE_ prefix). Leave these empty to disable the feature: the
+# button simply won't render and no Wallet API calls are made. All values come
+# from the Google Cloud / Pay & Wallet consoles (see README "Google Wallet").
+GOOGLE_WALLET_ISSUER_ID=
+# client_email from the service-account JSON (…@<project>.iam.gserviceaccount.com).
+GOOGLE_WALLET_SA_EMAIL=
+# private_key from the service-account JSON. Keep the literal \n sequences as-is
+# (Vercel stores them escaped; the code un-escapes them before signing).
+GOOGLE_WALLET_SA_PRIVATE_KEY=
+# Suffix of the event's Passes Class; classId = <ISSUER_ID>.<suffix>.
+GOOGLE_WALLET_CLASS_SUFFIX=wwwy3

--- a/ticket-system/README.md
+++ b/ticket-system/README.md
@@ -135,6 +135,11 @@ YAPPY_BTN_MERCHANT_ID, YAPPY_BTN_SECRET_KEY (base64, se muestra UNA vez)
 YAPPY_BTN_DOMAIN=https://entradas.stilllouder.space   # igual al portal
 YAPPY_BTN_ENV=test|prod
 YAPPY_BTN_CDN_URL             # opcional: override del CDN del web component
+# Google Wallet (vacías = el botón "Agregar a Google Wallet" se oculta solo)
+GOOGLE_WALLET_ISSUER_ID
+GOOGLE_WALLET_SA_EMAIL        # client_email del JSON de la cuenta de servicio
+GOOGLE_WALLET_SA_PRIVATE_KEY  # private_key del JSON (conservar los \n escapados)
+GOOGLE_WALLET_CLASS_SUFFIX=wwwy3
 ```
 
 ### 3. Desarrollo local
@@ -192,6 +197,52 @@ truncado a 16 bytes (32 hex). En la puerta:
 2. Solo si la firma es válida se ejecuta el `UPDATE` atómico que reclama el ticket.
 
 El secreto vive solo en el servidor; es imposible fabricar entradas válidas sin él.
+
+## Google Wallet (opcional — "Agregar a Google Wallet")
+
+Mejora opcional (fase 3): cada entrada puede guardarse en Google Wallet. El
+pase reutiliza **el mismo QR firmado HMAC** como código de barras
+(`QR_CODE`), así que el validador de puerta lo escanea idéntico al del correo —
+**no cambia la validación ni el cupo**. La legitimidad la respalda la firma
+HMAC, no Google Wallet.
+
+**Cómo está implementado:**
+
+- `api/_lib/google-wallet.ts` — todo server-only. Firma un JWT **RS256** con la
+  `private_key` de la cuenta de servicio usando `node:crypto` (sin dependencias
+  nuevas; la llave nunca llega al cliente). Expone:
+  - `buildWalletSaveUrl()` — cripto puro, sin red; arma el `eventTicketObject`
+    inline y devuelve el `https://pay.google.com/gp/v/save/<jwt>`. Si Wallet no
+    está configurado o algo falla, devuelve `null` y **nunca lanza** (el correo
+    y la emisión nunca se rompen por esto).
+  - `ensureEventTicketClass()` — crea la Passes Class del evento una sola vez
+    (idempotente: hace GET por id y solo crea con POST si da 404).
+- **Correo:** `api/_lib/email.ts` agrega un botón "Agregar a Google Wallet"
+  bajo cada QR, solo cuando las credenciales están configuradas.
+- **Endpoint on-demand:** `GET /api/wallet/google/:ticketId` redirige (302) al
+  `saveUrl`, o con `?format=json` lo devuelve. Acotado al ticket (su UUID es la
+  capacidad, igual que `/api/orders/:id/status`); no expone nada secreto.
+- **Clase del evento:** botón **"Clase de Google Wallet"** en el panel admin
+  (pestaña Resumen) → `POST /api/admin/wallet/google/ensure-class`. Córrelo una
+  vez tras configurar las variables `GOOGLE_WALLET_*`. Re-ejecutarlo es no-op.
+
+**Puesta en marcha:**
+
+1. En Google Cloud: habilitar la **Google Wallet API**, crear una cuenta de
+   servicio y descargar su llave **JSON**.
+2. En la **Pay & Wallet Console**: crear el Issuer y agregar el `client_email`
+   de la cuenta de servicio como usuario (Developer/Admin).
+3. Configurar `GOOGLE_WALLET_ISSUER_ID`, `GOOGLE_WALLET_SA_EMAIL`,
+   `GOOGLE_WALLET_SA_PRIVATE_KEY` y `GOOGLE_WALLET_CLASS_SUFFIX` (ver
+   `.env.example`).
+4. Pulsar **"Clase de Google Wallet"** en el panel admin (o `POST` al endpoint).
+
+**Demo mode:** mientras el Issuer esté en demo, el pase solo se guarda con
+cuentas de prueba (Admin/Developer o test accounts de la consola) y sale con
+**"[TEST ONLY]"** en el título. Tras obtener acceso de publicación, cambiar
+`reviewStatus` a `APPROVED` en `google-wallet.ts` y los pases salen a cualquier
+usuario sin el rótulo. **Apple Wallet queda fuera de alcance** (requiere cuenta
+Apple Developer de pago).
 
 ## Cómo se cumplen los criterios de aceptación
 

--- a/ticket-system/api/_lib/email.ts
+++ b/ticket-system/api/_lib/email.ts
@@ -1,6 +1,7 @@
 import { Resend } from 'resend';
 import { env } from './env.js';
 import { tokenToPngBuffer } from './qr.js';
+import { buildWalletSaveUrl } from './google-wallet.js';
 import type { Order } from './types.js';
 
 let resend: Resend | null = null;
@@ -74,6 +75,33 @@ export async function sendTicketEmail(order: Order, tokens: string[]): Promise<v
   const qrBlocks = tokens
     .map((token, i) => {
       const src = `${env.publicBaseUrl}/api/tickets/qr?t=${encodeURIComponent(token)}`;
+      // Optional "Add to Google Wallet" link (fase 3): only present when the
+      // Wallet credentials are configured; otherwise the row is omitted.
+      const walletUrl = buildWalletSaveUrl({
+        token,
+        buyerName: order.buyer_name,
+        tier: order.tier,
+        ticketNumber: `${order.id.slice(0, 8).toUpperCase()}-${i + 1}`
+      });
+      // Bulletproof (table + inline CSS) dark pill so it renders in every mail
+      // client — no SVG/webfont reliance. Links to the pay.google.com save URL.
+      const walletRow = walletUrl
+        ? `
+          <tr>
+            <td style="padding:0 16px 14px;text-align:center;">
+              <table role="presentation" cellpadding="0" cellspacing="0" align="center" style="margin:0 auto;">
+                <tr>
+                  <td style="border-radius:24px;background:#202124;">
+                    <a href="${walletUrl}" target="_blank" rel="noopener noreferrer"
+                       style="display:inline-block;padding:11px 22px;font-family:Arial,Helvetica,sans-serif;font-size:14px;font-weight:bold;color:#ffffff;text-decoration:none;border-radius:24px;">
+                      Agregar a Google Wallet
+                    </a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>`
+        : '';
       return `
         <table role="presentation" width="320" cellpadding="0" cellspacing="0" align="center"
                style="margin:22px auto;background:#ffffff;border:2px solid #15121c;border-radius:10px;border-collapse:separate;overflow:hidden;">
@@ -108,6 +136,7 @@ export async function sendTicketEmail(order: Order, tokens: string[]): Promise<v
               </div>
             </td>
           </tr>
+          ${walletRow}
         </table>`;
     })
     .join('');

--- a/ticket-system/api/_lib/env.ts
+++ b/ticket-system/api/_lib/env.ts
@@ -64,5 +64,28 @@ export const env = {
   },
   get yappyBtnEnv() {
     return optional('YAPPY_BTN_ENV', 'test');
+  },
+
+  // --- Google Wallet (server-only; signs the save-to-wallet JWT) -------------
+  // All four are optional: the feature is opt-in (fase 3). When the issuer id,
+  // service-account email or private key is missing, the "Add to Google Wallet"
+  // button simply never renders and no Wallet API calls are made — the presale
+  // is never blocked by this.
+  get googleWalletIssuerId() {
+    return optional('GOOGLE_WALLET_ISSUER_ID');
+  },
+  // client_email from the service-account JSON.
+  get googleWalletSaEmail() {
+    return optional('GOOGLE_WALLET_SA_EMAIL');
+  },
+  // private_key from the service-account JSON. Vercel env values keep the
+  // newlines escaped as the two characters "\n"; google-wallet.ts un-escapes
+  // them back into a real PEM before signing.
+  get googleWalletSaPrivateKey() {
+    return optional('GOOGLE_WALLET_SA_PRIVATE_KEY');
+  },
+  // Suffix of the event's Passes Class id; classId = `${issuerId}.${suffix}`.
+  get googleWalletClassSuffix() {
+    return optional('GOOGLE_WALLET_CLASS_SUFFIX', 'wwwy3');
   }
 };

--- a/ticket-system/api/_lib/google-wallet.ts
+++ b/ticket-system/api/_lib/google-wallet.ts
@@ -1,0 +1,225 @@
+import { createSign } from 'node:crypto';
+import { env } from './env.js';
+import { verifyToken } from './hmac.js';
+
+// =============================================================================
+// Google Wallet — "Add to Google Wallet" for WWWY3 event tickets.
+// =============================================================================
+// Everything here is SERVER-ONLY. The service-account private key signs an
+// RS256 JWT and NEVER reaches the browser (nothing in api/_lib is importable by
+// src/). The pass barcode reuses the SAME signed HMAC token that already prints
+// in the email, so the gate scanner accepts a Wallet pass byte-for-byte like a
+// printed/emailed QR. Google Wallet does not vouch for the ticket — the HMAC
+// signature does (validated at the door); Wallet is only a nicer container.
+//
+// Two responsibilities:
+//   1. buildWalletSaveUrl()       — pure crypto, no network. Builds the
+//      eventTicketObject inline, signs the save JWT, returns the pay.google.com
+//      save link. Used during issuance (email) and by the on-demand endpoint.
+//   2. ensureEventTicketClass()   — idempotent network call (admin-triggered)
+//      that creates the event's Passes Class once via the Wallet REST API.
+// =============================================================================
+
+const WALLET_API = 'https://walletobjects.googleapis.com/walletobjects/v1';
+const TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token';
+const WALLET_SCOPE = 'https://www.googleapis.com/auth/wallet_object.issuer';
+
+// Event facts mirror the confirmation email (which hardcodes "1 de agosto" /
+// "Hops"). Kept here as constants so the class metadata stays in one place;
+// adjust the address / start time here if the venue details firm up.
+const EVENT_NAME = 'When We Were Young 3 (WWWY3)';
+const VENUE_NAME = 'Hops';
+const VENUE_ADDRESS = 'Hops, Ciudad de Panamá, Panamá';
+const EVENT_START_ISO = '2026-08-01T20:00:00-05:00';
+const BACKGROUND_HEX = '#3e2768';
+
+const TIER_LABEL: Record<string, string> = {
+  preventa: 'Preventa',
+  general: 'General',
+  cortesia: 'Cortesía'
+};
+
+/** True only when the three required secrets are present. */
+export function isGoogleWalletConfigured(): boolean {
+  return Boolean(env.googleWalletIssuerId && env.googleWalletSaEmail && env.googleWalletSaPrivateKey);
+}
+
+function getClassId(): string {
+  return `${env.googleWalletIssuerId}.${env.googleWalletClassSuffix}`;
+}
+
+function getObjectId(ticketId: string): string {
+  // ticketId is a UUID (hex + hyphens) — already within the [A-Za-z0-9._-]
+  // charset Google requires for object ids.
+  return `${env.googleWalletIssuerId}.${ticketId}`;
+}
+
+// PEM as stored in env keeps newlines escaped as the literal characters "\n".
+function privateKeyPem(): string {
+  return env.googleWalletSaPrivateKey.replace(/\\n/g, '\n');
+}
+
+function base64url(input: Buffer | string): string {
+  return Buffer.from(input).toString('base64url');
+}
+
+// Minimal RS256 JWT — no dependency needed; node:crypto signs the PEM directly.
+function signRs256(claims: Record<string, unknown>): string {
+  const header = base64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const payload = base64url(JSON.stringify(claims));
+  const signingInput = `${header}.${payload}`;
+  const signer = createSign('RSA-SHA256');
+  signer.update(signingInput);
+  signer.end();
+  const signature = base64url(signer.sign(privateKeyPem()));
+  return `${signingInput}.${signature}`;
+}
+
+export interface WalletTicketInput {
+  // The signed HMAC token (WWWY3.<ticketId>.<sig>) — reused verbatim as the
+  // pass barcode. The ticket id is derived from it.
+  token: string;
+  buyerName: string;
+  tier: string;
+  // Human-readable number shown on the pass (e.g. "A1B2C3D4-1").
+  ticketNumber?: string;
+}
+
+/**
+ * Builds the pay.google.com save URL for one ticket. Pure crypto, no network.
+ * Returns null when Wallet isn't configured or the token is invalid, and never
+ * throws — so a misconfigured key degrades to "no button", never a broken
+ * email or a blocked issuance.
+ */
+export function buildWalletSaveUrl(input: WalletTicketInput): string | null {
+  if (!isGoogleWalletConfigured()) return null;
+  const ticketId = verifyToken(input.token);
+  if (!ticketId) return null;
+
+  try {
+    const eventTicketObject = {
+      id: getObjectId(ticketId),
+      classId: getClassId(),
+      state: 'ACTIVE',
+      barcode: { type: 'QR_CODE', value: input.token },
+      ticketHolderName: input.buyerName,
+      ticketNumber: input.ticketNumber ?? ticketId,
+      ticketType: {
+        defaultValue: { language: 'es', value: TIER_LABEL[input.tier] ?? input.tier }
+      }
+    };
+
+    // The class is referenced by classId only (it must already exist via
+    // ensureEventTicketClass) so the JWT — and therefore the URL — stays short.
+    const claims = {
+      iss: env.googleWalletSaEmail,
+      aud: 'google',
+      typ: 'savetowallet',
+      iat: Math.floor(Date.now() / 1000),
+      origins: [env.publicBaseUrl],
+      payload: { eventTicketObjects: [eventTicketObject] }
+    };
+
+    return `https://pay.google.com/gp/v/save/${signRs256(claims)}`;
+  } catch (err) {
+    console.error('[google-wallet] failed to build save url', err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+// --- Class creation (admin-triggered, idempotent) -----------------------------
+
+let cachedToken: { value: string; expiresAt: number } | null = null;
+
+// Mints an OAuth2 access token for the Wallet API via the JWT-bearer grant
+// (self-signed by the service account). Cached until shortly before expiry.
+async function getAccessToken(): Promise<string> {
+  const now = Math.floor(Date.now() / 1000);
+  if (cachedToken && cachedToken.expiresAt > now + 60) {
+    return cachedToken.value;
+  }
+
+  const assertion = signRs256({
+    iss: env.googleWalletSaEmail,
+    scope: WALLET_SCOPE,
+    aud: TOKEN_ENDPOINT,
+    iat: now,
+    exp: now + 3600
+  });
+
+  const res = await fetch(TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion
+    })
+  });
+
+  const data = (await res.json().catch(() => ({}))) as { access_token?: string; expires_in?: number; error_description?: string };
+  if (!res.ok || !data.access_token) {
+    throw new Error(`wallet oauth failed (${res.status}): ${data.error_description ?? 'no access_token'}`);
+  }
+
+  cachedToken = { value: data.access_token, expiresAt: now + (data.expires_in ?? 3600) };
+  return data.access_token;
+}
+
+function buildEventTicketClass(classId: string) {
+  return {
+    id: classId,
+    issuerName: 'Still Louder',
+    // UNDER_REVIEW works in demo mode; flip to APPROVED once Google grants
+    // publishing access.
+    reviewStatus: 'UNDER_REVIEW',
+    eventName: { defaultValue: { language: 'es', value: EVENT_NAME } },
+    venue: {
+      name: { defaultValue: { language: 'es', value: VENUE_NAME } },
+      address: { defaultValue: { language: 'es', value: VENUE_ADDRESS } }
+    },
+    dateTime: { start: EVENT_START_ISO },
+    // Logo / hero must be HTTPS, no redirects — served from this app's own
+    // public/ dir (same Vercel deployment as the API).
+    logo: { sourceUri: { uri: `${env.publicBaseUrl}/apple-touch-icon.png` } },
+    heroImage: { sourceUri: { uri: `${env.publicBaseUrl}/og-image.jpg` } },
+    hexBackgroundColor: BACKGROUND_HEX
+  };
+}
+
+export interface EnsureClassResult {
+  classId: string;
+  created: boolean;
+}
+
+/**
+ * Creates the event's Passes Class if it doesn't already exist. Idempotent:
+ * a GET that returns 200 means the class is there and nothing is recreated.
+ * Throws on real API errors so the admin sees them.
+ */
+export async function ensureEventTicketClass(): Promise<EnsureClassResult> {
+  const classId = getClassId();
+  const accessToken = await getAccessToken();
+
+  const getRes = await fetch(`${WALLET_API}/eventTicketClass/${encodeURIComponent(classId)}`, {
+    headers: { Authorization: `Bearer ${accessToken}` }
+  });
+  if (getRes.ok) {
+    return { classId, created: false };
+  }
+  if (getRes.status !== 404) {
+    const detail = await getRes.text().catch(() => '');
+    throw new Error(`wallet class lookup failed (${getRes.status}): ${detail.slice(0, 300)}`);
+  }
+
+  const postRes = await fetch(`${WALLET_API}/eventTicketClass`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(buildEventTicketClass(classId))
+  });
+  if (!postRes.ok) {
+    const detail = await postRes.text().catch(() => '');
+    throw new Error(`wallet class create failed (${postRes.status}): ${detail.slice(0, 300)}`);
+  }
+
+  return { classId, created: true };
+}

--- a/ticket-system/api/admin.ts
+++ b/ticket-system/api/admin.ts
@@ -4,6 +4,7 @@ import { isAdmin, isCron } from './_lib/auth.js';
 import { methodNotAllowed, parseBody, sendJson, withErrorHandling } from './_lib/http.js';
 import { issueOrder, resendOrderEmail, IssueError } from './_lib/issue.js';
 import { MAX_QUANTITY_PER_ORDER } from './_lib/pricing.js';
+import { ensureEventTicketClass, isGoogleWalletConfigured } from './_lib/google-wallet.js';
 import type { Order, PresaleStatus, Ticket } from './_lib/types.js';
 
 // Single function for EVERY /api/admin/* route. Vercel Hobby caps a deployment
@@ -24,6 +25,7 @@ import type { Order, PresaleStatus, Ticket } from './_lib/types.js';
 //   POST /api/admin/tickets/:id/revoke         valid -> void (gate will reject it)
 //   POST /api/admin/tickets/:id/unrevoke       void -> valid
 //   POST /api/admin/courtesy                   create + issue a courtesy order ($0)
+//   POST /api/admin/wallet/google/ensure-class create the Google Wallet event class (idempotent)
 //
 // Everything is admin-gated except orders/cleanup, which also accepts the cron
 // secret (the daily Vercel Cron hits it with GET).
@@ -76,6 +78,10 @@ export default withErrorHandling(async (req: VercelRequest, res: VercelResponse)
   if (route === 'courtesy') {
     if (req.method !== 'POST') return methodNotAllowed(res, ['POST']);
     return createCourtesy(req, res);
+  }
+  if (route === 'wallet/google/ensure-class') {
+    if (req.method !== 'POST') return methodNotAllowed(res, ['POST']);
+    return ensureWalletClass(res);
   }
 
   return sendJson(res, 404, { error: 'not_found' });
@@ -406,4 +412,17 @@ async function createCourtesy(req: VercelRequest, res: VercelResponse): Promise<
     ticketCount: result.ticketCount,
     emailed: result.emailed
   });
+}
+
+// --- Google Wallet -------------------------------------------------------------
+
+// Creates the event's Passes Class once (idempotent — see ensureEventTicketClass).
+// Run it after setting the GOOGLE_WALLET_* env vars and before passes can be
+// saved; re-running it when the class already exists is a no-op.
+async function ensureWalletClass(res: VercelResponse): Promise<void> {
+  if (!isGoogleWalletConfigured()) {
+    return sendJson(res, 400, { error: 'google_wallet_not_configured' });
+  }
+  const result = await ensureEventTicketClass();
+  return sendJson(res, 200, result);
 }

--- a/ticket-system/api/wallet/google/[ticketId].ts
+++ b/ticket-system/api/wallet/google/[ticketId].ts
@@ -1,0 +1,63 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { getSupabase } from '../../_lib/supabase.js';
+import { methodNotAllowed, sendJson, withErrorHandling } from '../../_lib/http.js';
+import { makeToken } from '../../_lib/hmac.js';
+import { buildWalletSaveUrl, isGoogleWalletConfigured } from '../../_lib/google-wallet.js';
+
+// =============================================================================
+// GET /api/wallet/google/:ticketId — on-demand "Add to Google Wallet" link.
+// =============================================================================
+// Alternative to the button embedded in the confirmation email (e.g. for the
+// success page). Scoped to the ticket: knowing its UUID is the capability, the
+// same model as /api/orders/:id/status. The pass barcode is the ticket's own
+// signed HMAC token, so legitimacy is enforced at the door regardless of who
+// fetches this — nothing secret is exposed.
+//
+// Default: 302 redirect to the pay.google.com save URL. With ?format=json it
+// returns { saveUrl } instead (handy for rendering a button client-side).
+// =============================================================================
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+interface TicketRow {
+  id: string;
+  tier: string;
+  status: string;
+  orders: { id: string; buyer_name: string } | null;
+}
+
+export default withErrorHandling(async (req: VercelRequest, res: VercelResponse) => {
+  if (req.method !== 'GET') return methodNotAllowed(res, ['GET']);
+  if (!isGoogleWalletConfigured()) return sendJson(res, 404, { error: 'not_available' });
+
+  const ticketId = typeof req.query.ticketId === 'string' ? req.query.ticketId : '';
+  if (!UUID_RE.test(ticketId)) return sendJson(res, 400, { error: 'invalid_ticket_id' });
+
+  const { data, error } = await getSupabase()
+    .from('tickets')
+    .select('id, tier, status, orders!inner(id, buyer_name)')
+    .eq('id', ticketId)
+    .maybeSingle<TicketRow>();
+  if (error) throw new Error(`wallet ticket lookup failed: ${error.message}`);
+  if (!data) return sendJson(res, 404, { error: 'ticket_not_found' });
+  // Revoked tickets won't pass the gate, so don't hand out a Wallet pass for one.
+  if (data.status === 'void') return sendJson(res, 410, { error: 'ticket_void' });
+
+  const saveUrl = buildWalletSaveUrl({
+    token: makeToken(data.id),
+    buyerName: data.orders?.buyer_name ?? '',
+    tier: data.tier,
+    ticketNumber: (data.orders?.id ?? data.id).slice(0, 8).toUpperCase()
+  });
+  if (!saveUrl) return sendJson(res, 500, { error: 'wallet_url_failed' });
+
+  const format = typeof req.query.format === 'string' ? req.query.format : '';
+  if (format === 'json') {
+    return sendJson(res, 200, { saveUrl });
+  }
+
+  res.setHeader('Cache-Control', 'no-store');
+  res.statusCode = 302;
+  res.setHeader('Location', saveUrl);
+  res.end();
+});

--- a/ticket-system/src/admin/App.tsx
+++ b/ticket-system/src/admin/App.tsx
@@ -3,6 +3,7 @@ import {
   cancelOrder,
   cleanupExpired,
   createCourtesyOrder,
+  ensureWalletClass,
   fetchAdminOrders,
   fetchAdminTickets,
   markOrderPaid,
@@ -240,6 +241,23 @@ function ResumenTab({ password }: { password: string }) {
     }
   }
 
+  async function handleWalletClass() {
+    if (!window.confirm('¿Crear/verificar la clase de Google Wallet del evento? Es seguro repetirlo.')) return;
+    setError('');
+    try {
+      const { classId, created } = await ensureWalletClass(password);
+      setMessage(created ? `✓ Clase de Google Wallet creada (${classId}).` : `✓ La clase de Google Wallet ya existía (${classId}).`);
+    } catch (err) {
+      const code = (err as Error & { code?: string }).code;
+      setMessage('');
+      setError(
+        code === 'google_wallet_not_configured'
+          ? 'Google Wallet no está configurado (faltan las variables GOOGLE_WALLET_*).'
+          : 'Error al crear la clase de Google Wallet.'
+      );
+    }
+  }
+
   if (!stats || !ticketStats) {
     return error ? <div className="alert alert--error">{error}</div> : <p className="muted">Cargando…</p>;
   }
@@ -289,6 +307,9 @@ function ResumenTab({ password }: { password: string }) {
           )}
           <button className="secondary" onClick={handleCleanup}>
             Limpiar pendientes vencidas
+          </button>
+          <button className="secondary" onClick={handleWalletClass}>
+            Clase de Google Wallet
           </button>
         </div>
       </div>

--- a/ticket-system/src/shared/api.ts
+++ b/ticket-system/src/shared/api.ts
@@ -203,6 +203,15 @@ export function cleanupExpired(password: string): Promise<{ cancelled: number }>
   });
 }
 
+export function ensureWalletClass(
+  password: string
+): Promise<{ classId: string; created: boolean }> {
+  return request('/api/admin/wallet/google/ensure-class', {
+    method: 'POST',
+    headers: authHeader(password)
+  });
+}
+
 export function cancelOrder(
   password: string,
   orderId: string


### PR DESCRIPTION
## Summary

Implements optional Google Wallet support (fase 3) to allow attendees to save WWWY3 event tickets to their Google Wallet. The feature is entirely opt-in: when credentials are not configured, the "Add to Google Wallet" button simply doesn't render and no API calls are made.

## Key Changes

- **New module `api/_lib/google-wallet.ts`**: Server-only crypto logic that:
  - Signs RS256 JWTs using the service-account private key (via `node:crypto`, no new dependencies)
  - Exports `buildWalletSaveUrl()` to generate the `pay.google.com/gp/v/save/` link with an inline `eventTicketObject`
  - Exports `ensureEventTicketClass()` to idempotently create the event's Passes Class via the Wallet REST API (with OAuth2 token caching)
  - Returns `null` gracefully if configuration is missing or signing fails, never throwing

- **New endpoint `api/wallet/google/[ticketId].ts`**: On-demand "Add to Google Wallet" link:
  - `GET /api/wallet/google/:ticketId` redirects (302) to the save URL, or returns `{ saveUrl }` with `?format=json`
  - Scoped to the ticket UUID (same capability model as `/api/orders/:id/status`)
  - Reuses the ticket's signed HMAC token as the pass barcode, so legitimacy is enforced at the gate regardless of Wallet

- **Email integration**: `api/_lib/email.ts` now includes a dark pill button "Agregar a Google Wallet" below each QR code (only when credentials are configured)

- **Admin panel**: New "Clase de Google Wallet" button in the Resumen tab that triggers `POST /api/admin/wallet/google/ensure-class` to create/verify the event class

- **Environment variables** (`api/_lib/env.ts` and `.env.example`):
  - `GOOGLE_WALLET_ISSUER_ID`
  - `GOOGLE_WALLET_SA_EMAIL` (service-account client_email)
  - `GOOGLE_WALLET_SA_PRIVATE_KEY` (service-account private_key, with `\n` escaped)
  - `GOOGLE_WALLET_CLASS_SUFFIX` (defaults to `wwwy3`)

- **Client API** (`src/shared/api.ts`): New `ensureWalletClass()` function for the admin panel

- **Documentation** (`ticket-system/README.md`): Comprehensive setup guide covering Google Cloud/Pay & Wallet console configuration, demo mode behavior, and implementation details

## Implementation Details

- The pass barcode reuses the **same signed HMAC token** that prints in the email QR, so the gate scanner accepts a Wallet pass byte-for-byte like a printed ticket — no validation changes
- Google Wallet does not vouch for the ticket; the HMAC signature does (validated at the door)
- Service-account private key is never exposed to the browser; all signing happens server-side
- Feature degrades gracefully: missing credentials cause the button to not render, never breaking email or issuance
- Class creation is idempotent: a GET check returns 200 if it exists, POST only runs on 404
- Demo mode: while the Issuer is in demo, passes only save with test accounts and show "[TEST ONLY]" in the title

https://claude.ai/code/session_01KaFmnbNT1VDAb8UqvZZimi