### PR TITLE
feat: avisar que los QR de fase de pruebas no serán válidos

### DIFF
--- a/ticket-system/api/_lib/email.ts
+++ b/ticket-system/api/_lib/email.ts
@@ -39,6 +39,16 @@ function formatPanamaDate(iso: string): string {
   }
 }
 
+// Mientras la BD aún tiene datos de pruebas, todo QR emitido antes de que abra
+// la preventa será purgado: el correo lo advierte para que nadie guarde una
+// entrada de prueba creyéndola válida. Espejo de EVENT.presaleStart en el
+// cliente (src/shared/config.ts); el aviso se apaga solo al llegar la fecha.
+const PRESALE_START_ISO = '2026-06-15T00:00:00-05:00';
+
+function isTestPhase(now: Date = new Date()): boolean {
+  return now.getTime() < new Date(PRESALE_START_ISO).getTime();
+}
+
 function escapeHtml(value: string): string {
   return value
     .replace(/&/g, '&amp;')
@@ -147,6 +157,18 @@ export async function sendTicketEmail(order: Order, tokens: string[]): Promise<v
       <td style="padding:7px 0;font-size:15px;color:#15121c;font-weight:bold;">${value}</td>
     </tr>`;
 
+  const testPhaseNotice = isTestPhase()
+    ? `
+            <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:14px;">
+              <tr>
+                <td style="background:#fff3cd;border:2px solid #b3791a;border-radius:10px;padding:14px 18px;font-size:14px;line-height:1.55;color:#6b4a00;">
+                  <strong>⚠️ Fase de pruebas:</strong> esta entrada fue generada antes del inicio de
+                  la preventa (15 de junio) y <strong>no será válida</strong> para el evento.
+                </td>
+              </tr>
+            </table>`
+    : '';
+
   // Versión clara "enmarcada": franjas oscuras arriba y abajo encierran un cuerpo
   // blanco neutro (como el papel del flyer original) con acentos morado/rosa, para
   // que no se vea plano junto al header fuerte.
@@ -206,6 +228,7 @@ export async function sendTicketEmail(order: Order, tokens: string[]): Promise<v
                 </td>
               </tr>
             </table>
+            ${testPhaseNotice}
             ${qrBlocks}
           </td>
         </tr>

--- a/ticket-system/src/entradas/App.tsx
+++ b/ticket-system/src/entradas/App.tsx
@@ -194,6 +194,7 @@ export default function App() {
           <Countdown />
         </div>
         <PresaleIndicator presale={presale} presaleEnded={presaleEnded} />
+        <TestPhaseNotice />
 
         {/* Formulario: temático pero LEGIBLE (sin filtro rasgado en inputs) */}
         <form className="tk-form tk-reveal" onSubmit={handleSubmit}>
@@ -322,6 +323,25 @@ function Decorations() {
   );
 }
 
+/**
+ * Mientras la BD aún tiene datos de pruebas (antes de que abra la preventa),
+ * cualquier QR emitido será purgado y no servirá en puerta. El aviso se apaga
+ * solo el 15 de junio sin necesidad de redeploy. Espejo del aviso del correo
+ * en api/_lib/email.ts.
+ */
+function TestPhaseNotice() {
+  if (Date.now() >= new Date(EVENT.presaleStart).getTime()) return null;
+  return (
+    <div className="tk-test-notice tk-reveal" role="alert">
+      <strong>⚠️ Fase de pruebas</strong>
+      <p>
+        Los códigos QR generados antes del inicio de la preventa (15 de junio) <b>no serán
+        válidos</b> para el evento.
+      </p>
+    </div>
+  );
+}
+
 function PresaleIndicator({
   presale,
   presaleEnded
@@ -378,6 +398,8 @@ function Confirmation({
             <div className="tk-byline">{EVENT.shortName} · by {EVENT.band}</div>
           </div>
         </div>
+
+        <TestPhaseNotice />
 
         <div className="tk-form tk-success tk-reveal">
           <p style={{ fontSize: 16 }}>

--- a/ticket-system/src/entradas/theme.css
+++ b/ticket-system/src/entradas/theme.css
@@ -343,6 +343,33 @@ body::before {
   color: var(--paper);
 }
 
+/* ===================== AVISO FASE DE PRUEBAS ===================== */
+/* Sticker de advertencia ámbar: mismo lenguaje de parche duro que el form. */
+.tk-test-notice {
+  max-width: 460px;
+  margin: 18px auto 0;
+  background: #ffe9a8;
+  color: #4a3200;
+  border: 3px solid var(--ink);
+  border-radius: 4px;
+  padding: 12px 16px;
+  font-family: var(--font-body);
+  font-size: 14px;
+  line-height: 1.5;
+  text-align: center;
+  box-shadow: 0 5px 0 var(--ink);
+}
+.tk-test-notice strong {
+  display: block;
+  font-family: var(--font-patch);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+.tk-test-notice p {
+  margin: 0;
+}
+
 /* ===================== FORM (legible, tema sutil) ===================== */
 /* El form vive en un parche de papel SÓLIDO con borde recto y sombra dura:
    look de sticker, pero sin el filtro rasgado para máxima legibilidad. */


### PR DESCRIPTION
Mientras la BD contenga datos de prueba, todo QR emitido antes del
inicio de la preventa (15 de junio) será purgado. Se agrega un aviso
ámbar en /entradas (formulario y confirmación) y una caja de
advertencia en el correo que entrega los QR. Ambos están condicionados
por fecha y desaparecen solos al abrir la preventa, sin redeploy.

https://claude.ai/code/session_01F9MkPzhgYXBpdsMha8wUMi