### PR TITLE
fix: only invite email replies when EMAIL_REPLY_TO is configured

### DIFF
--- a/ticket-system/.env.example
+++ b/ticket-system/.env.example
@@ -14,6 +14,11 @@ SUPABASE_SERVICE_ROLE_KEY=
 RESEND_API_KEY=
 # From address — domain must be verified in Resend (DKIM/SPF/DMARC).
 EMAIL_FROM="Still Louder <entradas@stilllouder.space>"
+# Reply-To for the buyer's ticket email. The Resend domain only SENDS mail, so
+# replies to entradas@ go nowhere; set this to a real inbox (e.g. the band's
+# Gmail) so "reply to this email" works. Optional: leave empty and the email
+# won't invite replies (it points to @stilllouder social channels instead).
+EMAIL_REPLY_TO=
 # Internal recipient(s) notified when a purchase is registered (order created).
 # Optional: leave empty to disable. Accepts a comma-separated list of addresses.
 ORDER_NOTIFICATION_EMAIL=

--- a/ticket-system/README.md
+++ b/ticket-system/README.md
@@ -121,6 +121,8 @@ Todas son **server-only**; ninguna se expone al navegador.
 ```
 SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
 RESEND_API_KEY, EMAIL_FROM="Still Louder <entradas@stilllouder.space>"
+EMAIL_REPLY_TO                # opcional: buzón real (p. ej. Gmail) que recibe las respuestas
+                              # del comprador; sin esto el correo no invita a responder
 ORDER_NOTIFICATION_EMAIL      # opcional: aviso interno al registrarse una compra (lista separada por comas)
 TICKET_HMAC_SECRET            # openssl rand -hex 32
 ADMIN_PASSWORD, STAFF_PASSWORD
@@ -269,7 +271,12 @@ Apple Developer de pago).
   esperar a la limpieza. `cleanup_expired_orders` (cron diario + botón admin) es
   solo housekeeping: marca esas pendientes como `cancelled`.
 - **Correo desde `entradas@stilllouder.space`:** configurable vía `EMAIL_FROM`
-  (requiere dominio verificado en Resend — DKIM/SPF/DMARC).
+  (requiere dominio verificado en Resend — DKIM/SPF/DMARC). El dominio solo
+  **envía**: no hay recepción configurada, así que responder a `entradas@` no
+  llega a nadie. `EMAIL_REPLY_TO` (opcional) pone un buzón real (p. ej. el
+  Gmail de la banda) en el header Reply-To y habilita la frase "responde a
+  este correo" en el footer; sin configurarla, el footer solo menciona los
+  canales oficiales (@stilllouder).
 
 ## Notas operativas
 

--- a/ticket-system/api/_lib/email.ts
+++ b/ticket-system/api/_lib/email.ts
@@ -169,6 +169,14 @@ export async function sendTicketEmail(order: Order, tokens: string[]): Promise<v
             </table>`
     : '';
 
+  // "Responde a este correo" solo es honesto si hay Reply-To configurado: el
+  // dominio en Resend solo envía, así que sin EMAIL_REPLY_TO una respuesta a
+  // entradas@ se pierde y el footer debe apuntar únicamente a las redes.
+  const replyTo = env.emailReplyTo;
+  const contactLine = replyTo
+    ? '¿Dudas? Responde a este correo o escríbenos por nuestros canales oficiales:'
+    : '¿Dudas? Escríbenos por nuestros canales oficiales:';
+
   // Versión clara "enmarcada": franjas oscuras arriba y abajo encierran un cuerpo
   // blanco neutro (como el papel del flyer original) con acentos morado/rosa, para
   // que no se vea plano junto al header fuerte.
@@ -237,7 +245,7 @@ export async function sendTicketEmail(order: Order, tokens: string[]): Promise<v
         <tr>
           <td style="background:#3e2768;padding:20px 24px;text-align:center;">
             <div style="font-size:13px;color:#e7dcf7;line-height:1.6;">
-              ¿Dudas? Responde a este correo o escríbenos por nuestros canales oficiales:
+              ${contactLine}
               <strong style="color:#ff6cb6;">@stilllouder</strong>.
             </div>
             <div style="font-family:${patchFont};font-size:10px;letter-spacing:2px;color:#9b86c4;text-transform:uppercase;margin-top:10px;">
@@ -251,6 +259,7 @@ export async function sendTicketEmail(order: Order, tokens: string[]): Promise<v
   await getResend().emails.send({
     from: env.emailFrom,
     to: order.buyer_email,
+    ...(replyTo ? { replyTo } : {}),
     subject: 'Tu entrada para WWWY3 — Still Louder',
     html,
     attachments

--- a/ticket-system/api/_lib/env.ts
+++ b/ticket-system/api/_lib/env.ts
@@ -28,6 +28,13 @@ export const env = {
   get emailFrom() {
     return optional('EMAIL_FROM', 'Still Louder <entradas@stilllouder.space>');
   },
+  // Dirección que recibe las respuestas del comprador (header Reply-To).
+  // El dominio en Resend solo está verificado para ENVIAR: sin esto, responder
+  // al correo de entradas no llega a nadie. Opcional: si no se configura, el
+  // correo no invita a responder y solo menciona los canales oficiales.
+  get emailReplyTo() {
+    return optional('EMAIL_REPLY_TO');
+  },
   // Destinatario(s) interno(s) que reciben aviso cuando se registra una compra.
   // Opcional: si no se configura, no se envía el aviso (feature opt-in).
   // Acepta varias direcciones separadas por coma.


### PR DESCRIPTION
The Resend domain is verified for sending only, so replies to
entradas@stilllouder.space were lost while the ticket email said
'responde a este correo'. Add an optional EMAIL_REPLY_TO env var that
sets the Reply-To header (e.g. the band's Gmail); when unset, the
footer points only to the official @stilllouder channels.

https://claude.ai/code/session_01HNiopHJ65XFHsfdvwZNaBW